### PR TITLE
Consolidate the key schedule

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -343,6 +343,7 @@ def SelectMode(psk, pskID, pkI):
 
 def KeySchedule(pkR, zz, enc, info, psk, pskID, pkI):
   salt = zero(Nh)
+  pskIDm = ""
   if psk:
     salt = psk
     pskIDm = pskID


### PR DESCRIPTION
Prior versions had a lot of repetitive logic in the `SetupX` functions.  This PR consolidates that logic into a single `KeySchedule` method with some optional inputs to reflect variation among the modes.  As a side effect, it's now trivial to add a mode where the initiator is authenticated to hold *both* a PSK and a private key.

NB: Based on top of #1, so this will read better once that is landed.