### PR TITLE
Add Export interface

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -402,7 +402,9 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkIm):
   secret = Extract(psk, zz)
   key = Expand(secret, concat("hpke key", context), Nk)
   nonce = Expand(secret, concat("hpke nonce", context), Nn)
-  return Context(key, nonce)
+  exporter_secret = Expand(secret, concat("hpke exp", context), Nk)
+
+  return Context(key, nonce, exporter_secret)
 ~~~~~
 
 Note that the context construction in the KeySchedule procedure is
@@ -603,6 +605,19 @@ def Context.Open(aad, ct):
     return OpenError
   self.IncrementSeq()
   return pt
+~~~~~
+
+## Secret Export {#kpke-export}
+
+HPKE provides a interface for exporting secrets from the encryption Context, similar
+to the TLS 1.3 exporter interface (See {{8446}}, Section 7.5). This interface takes as
+input a context string `exporter_context` and desired length `L` (in octets), and produces
+a secret derived from the internal exporter secret using the corresponding KDF Expand
+function.
+
+~~~~~
+def Context.Export(exporter_context, L):
+  return Expand(self.exporter_secret, exporter_context, L)
 ~~~~~
 
 # Single-Shot APIs

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -390,7 +390,7 @@ def VerifyMode(mode, psk, pskID, pkIm):
   if mode == mode_psk_auth and (no_psk or no_pkIm):
     raise Exception("Invalid configuration for mode_psk_auth")
 
-def KeySchedule(mode, pkRm, zz, enc, info, psk, pskID, pkIm):
+def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkIm):
   VerifyMode(mode, psk, pskID, pkI)
 
   pkRm = Marshal(pkR)


### PR DESCRIPTION
Some applications of HPKE, such as ESNI, require a way to produce a unique value from a HPKE "invocation". (For ESNI, this would replace a client-generated nonce that is separate from HPKE entirely.) This change derives an additional exporter secret alongside the HPKE key and nonce, and then adds an Export API that can be used to derive additional secrets from this key using the KDF's `Expand` function.