### PR TITLE
Size of exporter_secret must be at least Nh, Nk is too small

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -232,7 +232,7 @@ HPKE variants rely on the following primitives:
     `salt`
   - Expand(PRK, info, L): Expand a pseudorandom key `PRK` using
     optional string `info` into `L` bytes of output keying material
-  - Nh: The output size of the Hash and Extract functions
+  - Nh: The output size of the Hash and Extract functions in octets
 
 * An AEAD encryption algorithm {{!RFC5116}}:
   - Seal(key, nonce, aad, pt): Encrypt and authenticate plaintext

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -415,7 +415,7 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
   secret = Extract(psk, zz)
   key = Expand(secret, concat("hpke key", context), Nk)
   nonce = Expand(secret, concat("hpke nonce", context), Nn)
-  exporter_secret = Expand(secret, concat("hpke exp", context), Nk)
+  exporter_secret = Expand(secret, concat("hpke exp", context), Nh)
 
   return Context(key, nonce, exporter_secret)
 ~~~~~


### PR DESCRIPTION
Currently, `exporter_secret` is created with Expand at a size of `Nk` octets. It is then used within Context.Export as first argument to another call to Expand. However, for HKDF-Expand, the RFC https://tools.ietf.org/html/rfc5869 defines the first input as follows (emphasis mine):

```
   Inputs:
      PRK      a pseudorandom key of *at least HashLen* octets
```

`HashLen` corresponds to `Nh` in the HPKE draft.

Looking at the definitions of `Nh`, `Nk`, and `Nn` in https://github.com/cfrg/draft-irtf-cfrg-hpke/blob/master/draft-irtf-cfrg-hpke.md#key-derivation-functions-kdfs-kdf-ids, it becomes clear that `Nh >= Nk` and `Nh >= Nn` for all combinations. Thus, to meet the security requirements of HKDF-Expand, `exporter_secret` should be generated with `Nh` bytes and not only with `Nk` bytes.

(Said differently, `exporter_secret` is not yet the key, but the input to `Expand`)