### PR TITLE
Add domain separation

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -830,7 +830,7 @@ protocols.
 
 The KeySchedule procedure also separates each Hash invocation, used when deriving
 pskID and info hashes, with unique one-byte prefixes. This ensures that each Hash
-computation (or oracle query) is independent {{BDG20}}.
+computation is independent {{BDG20}}.
 
 ## External Requirements / Non-Goals
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -22,20 +22,6 @@ author:
     email: karthikeyan.bhargavan@inria.fr
 
 informative:
-  BDG20:
-    title: Separate Your Domains - NIST PQC KEMs, Oracle Cloning and Read-Only Indifferentiability
-    target: https://eprint.iacr.org/2020/241.pdf
-    date: 2020
-    authors:
-      -
-        ins: Mihir Bellare
-        org: Department of Computer Science \& Engineering, University of California San Diego
-      -
-        ins: Hannah Davis
-        org: Department of Computer Science \& Engineering, University of California San Diego
-      -
-        ins: Felix Gunther
-        org: Department of Computer Science, ETH Zurich
   CS01:
     title: Design and Analysis of Practical Public-Key Encryption Schemes Secure against Adaptive Chosen Ciphertext Attack
     target: https://eprint.iacr.org/2001/108
@@ -437,8 +423,8 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
   pkRm = Marshal(pkR)
   identifier = "RFCXXXX"
   ciphersuite = concat(kem_id, kdf_id, aead_id)
-  pskID_hash = Hash(concat(0x00, pskID))
-  info_hash = Hash(concat(0x01, info))
+  pskID_hash = Hash(pskID)
+  info_hash = Hash(info)
   context = concat(identifier, ciphersuite, mode, enc, pkRm,
                    pkSm, pskID_hash, info_hash)
 
@@ -827,10 +813,6 @@ each Expand invocation. This ensures any secrets derived in HPKE are independent
 from those used in other protocols, even when derived from the same IKM (secret).
 Derivation of the KeySchedule 'secret' does not include domain separation as it
 is an intermediate value not exposed by the protocol.
-
-The KeySchedule procedure also separates each Hash invocation, used when deriving
-pskID and info hashes, with unique one-byte prefixes. This ensures that each Hash
-computation is independent {{BDG20}}.
 
 ## External Requirements / Non-Goals
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -825,8 +825,8 @@ publication.]]
 The KeySchedule procedure includes the domain separation string "RFCXXXX" in
 each Expand invocation. This ensures any secrets derived in HPKE are independent
 from those used in other protocols, even when derived from the same IKM (secret).
-This domain separation does not protect the KeySchedule 'secret' from use in other
-protocols.
+Derivation of the KeySchedule 'secret' does not include domain separation as it
+is an intermediate value not exposed by the protocol.
 
 The KeySchedule procedure also separates each Hash invocation, used when deriving
 pskID and info hashes, with unique one-byte prefixes. This ensures that each Hash

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -429,9 +429,9 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
                    pkSm, pskID_hash, info_hash)
 
   secret = Extract(psk, zz)
-  key = Expand(secret, concat("hpke key", context), Nk)
-  nonce = Expand(secret, concat("hpke nonce", context), Nn)
-  exporter_secret = Expand(secret, concat("hpke exp", context), Nh)
+  key = Expand(secret, concat("key", context), Nk)
+  nonce = Expand(secret, concat("nonce", context), Nn)
+  exporter_secret = Expand(secret, concat("exp", context), Nh)
 
   return Context(key, nonce, exporter_secret)
 ~~~~~


### PR DESCRIPTION
Add RFC number domain separation tag. Clone KeySchedule Hash calls with one-byte prefix.

This attempts to address #47.

