### PR TITLE
Modifications for IND-CCA-secure DHKEM and independent random oracles

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -916,29 +916,27 @@ knows all private keys of one participant.
 ## Domain Separation {#domain-separation}
 
 HPKE allows combining a DHKEM variant DHKEM(Group, KDF') and a KDF
-such that both KDFs are instantiated by the same KDF.
-
-By design, the calls to Extract and Expand inside DHKEM have different prefix-free
-prefixes for their second parameter than the calls to Extract and
-Expand in the remainder of HPKE. This is ensured by the different
-prefix-free label parameters in the calls to LabeledExtract and
-LabeledExpand. This serves to separate their input domains and justifies
-modeling them as independent functions even if instantiated by the same
-KDF.
+such that both KDFs are instantiated by the same KDF. By design, the
+calls to Extract and Expand inside DHKEM and the remainder of HPKE have
+different prefix-free encodings for the second parameter. This is
+achieved by the different prefix-free label parameters in the calls to
+LabeledExtract and LabeledExpand. This serves to separate the input
+domains of all Extract and Expand invokations. It also justifies modeling
+them as independent functions even if instantiated by the same KDF.
 
 Future KEM instantiations MUST ensure that all internal invocations of
 Extract and Expand can be modeled as functions independent from the
 invocations of Extract and Expand in the remainder of HPKE. One way to
 ensure this is by using an equal or similar prefixing scheme with
 an identifier different from "RFCXXXX ". Particular attention needs to
-be paid if the KEM directly invokes a function that is used internally
-in HPKE's Extract or Expand, like Hash in case of HKDF. It MUST be
-ensured that inputs to these invokation cannot collide with inputs used
-inside Extract or Expand. To avoid the latter, HPKE's KeySchedule uses
-Extract instead of Hash on the arbitrary-length inputs `info`, `pskID`,
-and `psk`.
+be paid if the KEM directly invokes functions that are used internally
+in HPKE's Extract or Expand, such as Hash and HMAC in the case of HKDF.
+It MUST be ensured that inputs to these invokations cannot collide with
+inputs to the internal invokations of these functions inside Extract or
+Expand. To avoid the latter, HPKE's KeySchedule uses Extract instead of
+Hash on the arbitrary-length inputs `info`, `pskID`, and `psk`.
 
-The string literal "RFCXXX" used in LabeledExtract and LabeledExpand
+The string literal "RFCXXXX" used in LabeledExtract and LabeledExpand
 ensures that any secrets derived in HPKE are bound to the scheme's name,
 even when possibly derived from the same Diffie-Hellman or KEM shared
 secret as in another scheme.

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -820,6 +820,10 @@ separate the input domains of `HashDH` and `Hash`; this justifies
 modeling them as independent functions even when instantiated by the
 same hash function.
 
+At the same time, `label_hash` ensures that any secrets derived in
+HPKE are independent from those used in other protocols, even when
+derived from the same KEM shared secret.
+
 Users of HPKE who want to use a KEM other than DHKEM must make sure
 that any hash function used within this KEM can be modeled as a
 function independent from `Hash`.

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -886,18 +886,18 @@ difference into account, in addition to simply using a post-quantum KEM.
 
 ## Random Oracle Cloning / Domain Separation
 
-HPKE allows a choice of a DHKEM variant and a KDF such that the hash
-functions `HashDH` and `Hash` are instantiated by the same hash
-function. The prefixes `label_hashdh` and `label_hash` serve to
-separate the input domains of `HashDH` and `Hash`; this justifies
-modeling them as independent functions even when instantiated by the
-same hash function.
+HPKE allows combining a DHKEM variant DHKEM(Curve, Hash_kem) and a KDF
+such that the hash functions Hash_kem and Hash are instantiated by the
+same hash function. The prefixes used for the second parameter of the
+functions Extract_kem, Expand_kem, Extract, and Expand serve to separate
+their input domains; this justifies modeling them as independent
+functions even if instantiated by the same underlying hash function.
 
 Users of HPKE who want to use a KEM other than DHKEM must make sure
 that any hash function used within this KEM can be modeled as a
 function independent from `Hash`.
 
-At the same time, `label_hash` ensures that any secrets derived in HPKE
+The string literal `identifier` ensures that any secrets derived in HPKE
 are bound to the scheme's name, even when possibly derived from the
 same KEM shared secret as in another scheme.
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -303,8 +303,8 @@ providing the following operations:
   encoding the public key `pk`
 - Unmarshal(enc): Parse a byte string of length Npk to recover a
   public key
-- Nzz: The output size of the Hash_kem and Extract_kem functions
-  in bytes
+- Ndh: The length in bytes of a Diffie-Hellman shared secret produced
+  by the DH function of this KEM.
 
 Then we can construct a KEM called `DHKEM(Group, Hash_kem)` in the
 following way, where `Group` denotes the Diffie-Hellman group and
@@ -360,8 +360,9 @@ def AuthDecap(enc, skR, pkR, pkS):
   return zz, enc
 ~~~
 
-For the NIST curves P-256, P-384 and P-521, Ndh is equal to Npk.
-For the CFRG curves Curve25519 and Curve448, Ndh is equal to Npk.
+For the variants of DHKEM defined in this document, Ndh is equal to Npk,
+and the output length of the Hash_kem and Extract_kem functions is Nzz
+bytes.
 
 The GenerateKeyPair, Marshal, and Unmarshal functions are the same
 as for the underlying DH group.  The Marshal functions for the

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -497,7 +497,7 @@ TLS presentation syntax:
 
 ~~~~~
 struct {
-    uint8 identifier[12];
+    uint8 identifier[12] = "RFCXXXX HPKE";
 
     // Mode and algorithms
     uint16 kem_id;

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -296,7 +296,9 @@ following way, where `Group` denotes the Diffie-Hellman group and
 `Hash_kem` the hash function underlying KDF_kem:
 
 ~~~
-label_dh = "RFCXXXX DHKEM"
+def ExtractAndExpand(dh, context_kem):
+  prk = Extract_kem(0, concat("RFCXXXX DHKEM", dh))
+  return Expand_kem(prk, concat("prk", context_kem), Nzz)
 
 def Encap(pkR):
   skE, pkE = GenerateKeyPair()
@@ -306,8 +308,7 @@ def Encap(pkR):
   pkRm = Marshal(pkR)
   context_kem = concat(enc, pkRm)
 
-  prk = Extract_kem(0, concat("RFCXXXX DHKEM", dh))
-  zz  = Expand_kem(prk, concat("prk", context_kem), Nzz)
+  zz = ExtractAndExpand(dh, context_kem)
   return zz, enc
 
 def Decap(enc, skR, pkR):
@@ -317,8 +318,7 @@ def Decap(enc, skR, pkR):
   pkRm = Marshal(pkR)
   context_kem = concat(enc, pkRm)
 
-  prk = Extract_kem(0, concat("RFCXXXX DHKEM", dh))
-  zz  = Expand_kem(prk, concat("prk", context_kem), Nzz)
+  zz = ExtractAndExpand(dh, context_kem)
   return zz, enc
 
 def AuthEncap(pkR, skS, pkS):
@@ -330,8 +330,7 @@ def AuthEncap(pkR, skS, pkS):
   pkSm = Marshal(pkS)
   context_kem = concat(enc, pkRm, pkSm)
 
-  prk = Extract_kem(0, concat("RFCXXXX DHKEM", dh))
-  zz  = Expand_kem(prk, concat("prk", context_kem), Nzz)
+  zz = ExtractAndExpand(dh, context_kem)
   return zz, enc
 
 def AuthDecap(enc, skR, pkR, pkS):
@@ -342,8 +341,7 @@ def AuthDecap(enc, skR, pkR, pkS):
   pkSm = Marshal(pkS)
   context_kem = concat(enc, pkRm, pkSm)
 
-  prk = Extract_kem(0, concat("RFCXXXX DHKEM", dh))
-  zz  = Expand_kem(prk, concat("prk", context_kem), Nzz)
+  zz = ExtractAndExpand(dh, context_kem)
   return zz, enc
 ~~~
 \[\[RFC editor: please change "RFCXXXX" to the correct number before publication.]]

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -250,14 +250,12 @@ HPKE variants rely on the following primitives:
   - Npk: The length in bytes of an encoded public key for this KEM
 
 * A Key Derivation Function (KDF):
-  - Hash(m): Compute the cryptographic hash of input message `m`
   - Extract(salt, IKM): Extract a pseudorandom key of fixed length
     from input keying material `IKM` and an optional byte string
     `salt`
   - Expand(PRK, info, L): Expand a pseudorandom key `PRK` using
     optional string `info` into `L` bytes of output keying material
-  - Nb: The block size of the Hash function in bytes
-  - Nh: The output size of the Hash and Extract functions in bytes
+  - Nh: The output size of the Extract function in bytes
 
 * An AEAD encryption algorithm {{!RFC5116}}:
   - Seal(key, nonce, aad, pt): Encrypt and authenticate plaintext
@@ -368,8 +366,7 @@ a KDF for the remainder of HPKE, and {{domain-separation}} for the
 rationale of the labels.
 
 For the variants of DHKEM defined in this document, Ndh is equal to Npk,
-and the output length of the KDF's Hash and Extract functions is Nzz
-bytes.
+and the output length of the KDF's Extract function is Nzz bytes.
 
 The GenerateKeyPair, Marshal, and Unmarshal functions are the same
 as for the underlying DH group.  The Marshal functions for the
@@ -941,7 +938,7 @@ be paid if the KEM directly invokes functions that are used internally
 in HPKE's Extract or Expand, such as Hash and HMAC in the case of HKDF.
 It MUST be ensured that inputs to these invocations cannot collide with
 inputs to the internal invocations of these functions inside Extract or
-Expand. To avoid the latter, HPKE's KeySchedule uses Extract instead of
+Expand. In HPKE's KeySchedule this is avoided by using Extract instead of
 Hash on the arbitrary-length inputs `info`, `pskID`, and `psk`.
 
 The string literal "RFCXXXX" used in LabeledExtract and LabeledExpand
@@ -1059,7 +1056,7 @@ Template:
 
 * Value: The two-byte identifier for the algorithm
 * KDF: The name of the algorithm
-* Nh: The length in bytes of the output of the KDF
+* Nh: The output size of the Extract function in bytes
 * Reference: Where this algorithm is defined
 
 Initial contents: Provided in {{kdf-ids}}

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -840,11 +840,10 @@ any IND-CCA2 scheme, and the DH group and KDF satisfy the following
 conditions:
 
 - DH group: The gap Diffie-Hellman (GDH) problem is hard {{GAP}}.
-- HashDH: Indifferentiable from a random oracle.
-- Hash: Collision resistance.
-- Extract: Indifferentiable from a random oracle.
-- Expand: Behaves as a pseudorandom function wherein the first argument
-is the key.
+- Extract and Extract_kem: Indifferentiable from a random oracle,
+  respectively.
+- Expand and Expand_kem: Behave as a pseudorandom function, respectively,
+  wherein the first argument is the key.
 
 In particular, the KDFs and DH groups defined in this document (see
 {{kdf-ids}} and {{kem-ids}}) satisfy these properties.

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -329,6 +329,8 @@ curves referenced in {#ciphersuites} are as follows:
 
 * P-256: A single byte set to 4, followed by the X-coordinate and the
   Y-coordinate of the point, encoded as 32-byte big-endian integers
+* P-384: A single byte set to 4, followed by the X-coordinate and the
+  Y-coordinate of the point, encoded as 48-byte big-endian integers
 * P-521: A single byte set to 4, followed by the X-coordinate and the
   Y-coordinate of the point, encoded as 66-byte big-endian integers
 * Curve25519: The standard 32-byte representation of the public key

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -934,7 +934,9 @@ an identifier different from "RFCXXXX ". Particular attention needs to
 be paid if the KEM directly invokes a function that is used internally
 in HPKE's Extract or Expand, like Hash in case of HKDF. It MUST be
 ensured that inputs to these invokation cannot collide with inputs used
-inside Extract or Expand.
+inside Extract or Expand. To avoid the latter, HPKE's KeySchedule uses
+Extract instead of Hash on the arbitrary-length inputs `info`, `pskID`,
+and `psk`.
 
 The string literal "RFCXXX" used in LabeledExtract and LabeledExpand
 ensures that any secrets derived in HPKE are bound to the scheme's name,

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -290,9 +290,8 @@ def LabeledExpand(PRK, label, info, L):
 
 ## DH-Based KEM
 
-Suppose we are given an instantiation KDF_kem of KDF with functions
-Hash_kem, Extract_kem, and Expand_kem, and a Diffie-Hellman group
-providing the following operations:
+Suppose we are given a KDF, and a Diffie-Hellman group providing the
+following operations:
 
 - GenerateKeyPair(): Generate an ephemeral key pair `(sk, pk)`
   for the DH group in use
@@ -306,14 +305,14 @@ providing the following operations:
 - Ndh: The length in bytes of a Diffie-Hellman shared secret produced
   by the DH function of this KEM.
 
-Then we can construct a KEM called `DHKEM(Group, Hash_kem)` in the
+Then we can construct a KEM called `DHKEM(Group, KDF)` in the
 following way, where `Group` denotes the Diffie-Hellman group and
-`Hash_kem` the hash function underlying KDF_kem:
+`KDF` the KDF:
 
 ~~~
 def ExtractAndExpand(dh, context_kem):
-  prk = LabeledExtract_kem(0, "dh", dh)
-  return LabeledExpand_kem(prk, "prk", context_kem, Nzz)
+  prk = LabeledExtract(0, "dh", dh)
+  return LabeledExpand(prk, "prk", context_kem, Nzz)
 
 def Encap(pkR):
   skE, pkE = GenerateKeyPair()
@@ -360,8 +359,12 @@ def AuthDecap(enc, skR, pkR, pkS):
   return zz, enc
 ~~~
 
+The KDF used in DHKEM can be equal to or different from the KDF used
+in the remainder of HPKE depending on the chosen variant. See
+{{domain-separation}} for a security-related discussion.
+
 For the variants of DHKEM defined in this document, Ndh is equal to Npk,
-and the output length of the Hash_kem and Extract_kem functions is Nzz
+and the output length of the KDF's Hash and Extract functions is Nzz
 bytes.
 
 The GenerateKeyPair, Marshal, and Unmarshal functions are the same
@@ -757,14 +760,14 @@ def OpenAuthPSK(enc, skR, info, aad, ct, psk, pskID, pkS):
 
 ## Key Encapsulation Mechanisms (KEMs) {#kem-ids}
 
-| Value  | KEM                       | Nzz  | Nenc | Npk | Reference                    |
-|:-------|:--------------------------|:-----|:-----|:----|:-----------------------------|
-| 0x0000 | (reserved)                | N/A  | N/A  | N/A | N/A                          |
-| 0x0010 | DHKEM(P-256, SHA256)      | 32   | 65   | 65  | {{NISTCurves}}, {{?RFC6234}} |
-| 0x0011 | DHKEM(P-384, SHA384)      | 48   | 97   | 97  | {{NISTCurves}}, {{?RFC6234}} |
-| 0x0012 | DHKEM(P-521, SHA512)      | 64   | 133  | 133 | {{NISTCurves}}, {{?RFC6234}} |
-| 0x0020 | DHKEM(Curve25519, SHA256) | 32   | 32   | 32  | {{?RFC7748}}, {{?RFC6234}}   |
-| 0x0021 | DHKEM(Curve448, SHA512)   | 64   | 56   | 56  | {{?RFC7748}}, {{?RFC6234}}   |
+| Value  | KEM                            | Nzz  | Nenc | Npk | Reference                    |
+|:-------|:-------------------------------|:-----|:-----|:----|:-----------------------------|
+| 0x0000 | (reserved)                     | N/A  | N/A  | N/A | N/A                          |
+| 0x0010 | DHKEM(P-256, HKDF-SHA256)      | 32   | 65   | 65  | {{NISTCurves}}, {{?RFC5869}} |
+| 0x0011 | DHKEM(P-384, HKDF-SHA384)      | 48   | 97   | 97  | {{NISTCurves}}, {{?RFC5869}} |
+| 0x0012 | DHKEM(P-521, HKDF-SHA512)      | 64   | 133  | 133 | {{NISTCurves}}, {{?RFC5869}} |
+| 0x0020 | DHKEM(Curve25519, HKDF-SHA256) | 32   | 32   | 32  | {{?RFC7748}}, {{?RFC5869}}   |
+| 0x0021 | DHKEM(Curve448, HKDF-SHA512)   | 64   | 56   | 56  | {{?RFC7748}}, {{?RFC5869}}   |
 
 ### Marshal
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -820,13 +820,13 @@ separate the input domains of `HashDH` and `Hash`; this justifies
 modeling them as independent functions even when instantiated by the
 same hash function.
 
-At the same time, `label_hash` ensures that any secrets derived in
-HPKE are independent from those used in other protocols, even when
-derived from the same KEM shared secret.
-
 Users of HPKE who want to use a KEM other than DHKEM must make sure
 that any hash function used within this KEM can be modeled as a
 function independent from `Hash`.
+
+At the same time, `label_hash` ensures that any secrets derived in HPKE
+are bound to the scheme's name, even when possibly derived from the
+same KEM shared secret as in another scheme.
 
 ## External Requirements / Non-Goals
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -565,7 +565,7 @@ The primary differences from the base case are:
   to the KDF
 
 The PSK SHOULD be of length Nh bytes or longer, and SHOULD have
-Nh bytes of entropy or more. See {#security-psk} for a more detailed
+Nh bytes of entropy or more. See {{security-psk}} for a more detailed
 discussion.
 
 ~~~~~
@@ -643,7 +643,7 @@ def SetupAuthPSKR(enc, skR, info, psk, pskID, pkS):
 ~~~~~
 
 The PSK SHOULD be of length Nh bytes or longer, and SHOULD have
-Nh bytes of entropy or more. See {#security-psk} for a more detailed
+Nh bytes of entropy or more. See {{security-psk}} for a more detailed
 discussion.
 
 ## Encryption and Decryption {#hpke-dem}

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -311,7 +311,7 @@ following way, where `Group` denotes the Diffie-Hellman group and
 
 ~~~
 def ExtractAndExpand(dh, kemContext):
-  prk = LabeledExtract(0, "dh", dh)
+  prk = LabeledExtract(zero(Nh), "dh", dh)
   return LabeledExpand(prk, "prk", kemContext, Nzz)
 
 def Encap(pkR):
@@ -489,13 +489,13 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
   ciphersuite = concat(encode_big_endian(kem_id, 2),
                        encode_big_endian(kdf_id, 2),
                        encode_big_endian(aead_id, 2))
-  pskID_hash = LabeledExtract(0, "pskID", pskID)
-  info_hash = LabeledExtract(0, "info", info)
+  pskID_hash = LabeledExtract(zero(Nh), "pskID", pskID)
+  info_hash = LabeledExtract(zero(Nh), "info", info)
   context = concat(ciphersuite, mode, enc, pkRm,
                    pkSm, pskID_hash, info_hash)
 
   if len(psk) > Nb then:
-    psk = LabeledExtract(0, "psk", psk)
+    psk = LabeledExtract(zero(Nh), "psk", psk)
 
   secret = LabeledExtract(psk, "zz", zz)
   key = LabeledExpand(secret, "key", context, Nk)

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -913,22 +913,33 @@ Scenarios in which the adversary knows the KEM shared secret zz
 depend on the KEM. In the case of DHKEM, it is enough if the adversary
 knows all private keys of one participant. 
 
-## Domain Separation
+## Domain Separation {#domain-separation}
 
-HPKE allows combining a DHKEM variant DHKEM(Group, Hash_kem) and a KDF
-such that the hash functions Hash_kem and Hash are instantiated by the
-same hash function. The prefixes used for the second parameter of the
-functions Extract_kem, Expand_kem, Extract, and Expand serve to separate
-their input domains; this justifies modeling them as independent
-functions even if instantiated by the same underlying hash function.
+HPKE allows combining a DHKEM variant DHKEM(Group, KDF') and a KDF
+such that both KDFs are instantiated by the same KDF.
 
-Users of HPKE who want to use a KEM other than DHKEM must make sure
-that any hash function used within this KEM can be modeled as a
-function independent from `Hash`.
+By design, the calls to Extract and Expand inside DHKEM have different prefix-free
+prefixes for their second parameter than the calls to Extract and
+Expand in the remainder of HPKE. This is ensured by the different
+prefix-free label parameters in the calls to LabeledExtract and
+LabeledExpand. This serves to separate their input domains and justifies
+modeling them as independent functions even if instantiated by the same
+KDF.
 
-The string literal `identifier` ensures that any secrets derived in HPKE
-are bound to the scheme's name, even when possibly derived from the
-same KEM shared secret as in another scheme.
+Future KEM instantiations MUST ensure that all internal invocations of
+Extract and Expand can be modeled as functions independent from the
+invocations of Extract and Expand in the remainder of HPKE. One way to
+ensure this is by using an equal or similar prefixing scheme with
+an identifier different from "RFCXXXX ". Particular attention needs to
+be paid if the KEM directly invokes a function that is used internally
+in HPKE's Extract or Expand, like Hash in case of HKDF. It MUST be
+ensured that inputs to these invokation cannot collide with inputs used
+inside Extract or Expand.
+
+The string literal "RFCXXX" used in LabeledExtract and LabeledExpand
+ensures that any secrets derived in HPKE are bound to the scheme's name,
+even when possibly derived from the same Diffie-Hellman or KEM shared
+secret as in another scheme.
 
 ## External Requirements / Non-Goals
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -903,7 +903,7 @@ SHOULD at least have the security level provided by the PSK.
 
 ## Pre-Shared Key Recommendations {#security-psk}
 
-In mode PSK and mode AuthPSK, the PSK SHOULD be of length Nh bytes or
+In the PSK and AuthPSK modes, the PSK SHOULD be of length Nh bytes or
 longer, and SHOULD have Nh bytes of entropy or more. Using a PSK shorter
 than Nh bytes is permitted. A PSK that is longer than Nh bytes or that
 has more than Nh bytes of entropy, respectively, does not increase the

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -846,10 +846,12 @@ any IND-CCA2 scheme, and the DH group and KDF satisfy the following
 conditions:
 
 - DH group: The gap Diffie-Hellman (GDH) problem is hard {{GAP}}.
-- Extract and Extract_kem: Indifferentiable from a random oracle,
-  respectively.
-- Expand and Expand_kem: Behave as a pseudorandom function, respectively,
-  wherein the first argument is the key.
+- Extract and Expand (in DHKEM): Extract is indifferentiable from a
+  random oracle. Expand is a pseudorandom function, wherein the first
+  argument is the key.
+- Extract and Expand (elsewhere): Extract is indifferentiable from a
+  random oracle. Expand is a pseudorandom function, wherein the first
+  argument is the key.
 
 In particular, the KDFs and DH groups defined in this document (see
 {{kdf-ids}} and {{kem-ids}}) satisfy these properties.

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -490,7 +490,7 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
   context = concat(ciphersuite, mode, enc, pkRm,
                    pkSm, pskID_hash, info_hash)
 
-  if length(psk) > Nb then:
+  if len(psk) > Nb then:
     psk = LabeledExtract(0, "psk", psk)
 
   secret = LabeledExtract(psk, "zz", zz)

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -149,6 +149,24 @@ informative:
     target: https://portal.3gpp.org/desktopmodules/Specifications/SpecificationDetails.aspx?specificationId=3169
     date: 2019
 
+  HMAC:
+    title: To Hash or Not to Hash Again? (In)differentiability Results for H^2 and HMAC
+    target: https://eprint.iacr.org/2013/382
+    date: 2013
+    authors:
+      -
+        ins: Y. Dodis
+        org: Department of Computer Science, New York University
+      -
+        ins: Thomas Ristenpart
+        org: Department of Computer Sciences, University of Wisconsin–Madison
+      -
+        ins: John Steinberger
+        org: Institute of Theoretical Computer Science, Tsinghua University
+      -
+        ins: Stefano Tessaro
+        org: CSAIL, Massachusetts Institute of Technology
+
 --- abstract
 
 This document describes a scheme for hybrid public-key encryption
@@ -899,12 +917,19 @@ This is usually implemented by including these values explicitly into
 the context of the key derivation function used to compute the shared
 secret. This is also how DHKEM meets the requirement.
 
-## Choosing a KDF When Combining With a KEM {#kdf-choice}
+## Security Requirements on a KDF {#kdf-choice}
 
 The choice of the KDF for the remainder of HPKE should be made based on
 the security level provided by the KEM and, if applicable, by the PSK.
 The KDF SHOULD have at least have the security level of the KEM and
 SHOULD at least have the security level provided by the PSK.
+
+HPKE's KeySchedule uses LabeledExtract to convert an arbitrary-length
+PSK into a fixed-length PSK. This is necessary because of the
+restrictions on the key in HMAC's indifferentiability theorem {{HMAC}}.
+A future instantiation of HPKE MAY omit this line if: Extract is not
+instantiated by HKDF-Extract and there is an indifferentiability theorem
+for Extract without restriction on the key's length.
 
 ## Pre-Shared Key Recommendations {#security-psk}
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -291,8 +291,8 @@ providing the following operations:
 - Nzz: The output size of the Hash_kem and Extract_kem functions
   in bytes
 
-Then we can construct a KEM called `DHKEM(Curve, Hash_kem)` in the
-following way, where `Curve` denotes the Diffie-Hellman group and
+Then we can construct a KEM called `DHKEM(Group, Hash_kem)` in the
+following way, where `Group` denotes the Diffie-Hellman group and
 `Hash_kem` the hash function underlying KDF_kem:
 
 ~~~
@@ -886,7 +886,7 @@ difference into account, in addition to simply using a post-quantum KEM.
 
 ## Domain Separation
 
-HPKE allows combining a DHKEM variant DHKEM(Curve, Hash_kem) and a KDF
+HPKE allows combining a DHKEM variant DHKEM(Group, Hash_kem) and a KDF
 such that the hash functions Hash_kem and Hash are instantiated by the
 same hash function. The prefixes used for the second parameter of the
 functions Extract_kem, Expand_kem, Extract, and Expand serve to separate

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -918,11 +918,9 @@ and has access to an oracle that allows to distinguish between a good
 and a wrong PSK, it can perform a dictionary attack on the PSK. This
 oracle can be the decryption operation on a captured HPKE ciphertext or
 any other recipient behavior which is observably different when using a
-wrong PSK.
-
-Scenarios in which the adversary knows the KEM shared secret zz
-depend on the KEM. In the case of DHKEM, it is enough if the adversary
-knows all private keys of one participant. 
+wrong PSK. The adversary knows the KEM shared secret zz if it knows all
+KEM private keys of one participant. In the PSK mode this is trivially
+the case if the adversary acts as sender.
 
 ## Domain Separation {#domain-separation}
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -767,6 +767,7 @@ any IND-CCA2 scheme, and the DH group and KDF satisfy the following
 conditions:
 
 - DH group: The gap Diffie-Hellman (GDH) problem is hard {{GAP}}.
+- HashDH: Indifferentiable from a random oracle.
 - Hash: Collision resistance.
 - Extract: Indifferentiable from a random oracle.
 - Expand: Behaves as a pseudorandom function wherein the first argument

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -884,7 +884,7 @@ security models and assumptions, and do not consider attackers capable of quantu
 computation. A full proof of post-quantum security would need to take this
 difference into account, in addition to simply using a post-quantum KEM.
 
-## Random Oracle Cloning / Domain Separation
+## Domain Separation
 
 HPKE allows combining a DHKEM variant DHKEM(Curve, Hash_kem) and a KDF
 such that the hash functions Hash_kem and Hash are instantiated by the

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -498,8 +498,7 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
   context = concat(ciphersuite, mode, enc, pkRm,
                    pkSm, pskID_hash, info_hash)
 
-  if len(psk) > Nb then:
-    psk = LabeledExtract(zero(Nh), "psk", psk)
+  psk = LabeledExtract(zero(Nh), "psk", psk)
 
   secret = LabeledExtract(psk, "zz", zz)
   key = LabeledExpand(secret, "key", context, Nk)

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -911,14 +911,14 @@ security level of HPKE, because the extraction step involving the PSK
 only outputs Nh bytes.
 
 HPKE is specified to use HKDF as key derivation function. HKDF is not
-designed to slow down dictionary attacks, see {{?RFC5869}}. Thus,
-HPKE's PSK mechanism is not suitable for use with a low-entropy
-password as the PSK: in scenarios in which the adversary knows the
-KEM shared secret zz and has access to an oracle for decryption success
-of an HPKE ciphertext, it can perform a dictionary attack on the PSK.
-If an application does not use Seal to create HPKE ciphertexts but only
-the Export interface, the adversary can rely on other recipient behavior
-which is observably different when using a wrong key.
+designed to slow down dictionary attacks, see {{?RFC5869}}. Thus, HPKE's
+PSK mechanism is not suitable for use with a low-entropy password as the
+PSK: in scenarios in which the adversary knows the KEM shared secret zz
+and has access to an oracle that allows to distinguish between a good
+and a wrong PSK, it can perform a dictionary attack on the PSK. This
+oracle can be the decryption operation on a captured HPKE ciphertext or
+any other recipient behavior which is observably different when using a
+wrong PSK.
 
 Scenarios in which the adversary knows the KEM shared secret zz
 depend on the KEM. In the case of DHKEM, it is enough if the adversary

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -921,7 +921,7 @@ calls to Extract and Expand inside DHKEM and the remainder of HPKE have
 different prefix-free encodings for the second parameter. This is
 achieved by the different prefix-free label parameters in the calls to
 LabeledExtract and LabeledExpand. This serves to separate the input
-domains of all Extract and Expand invokations. It also justifies modeling
+domains of all Extract and Expand invocations. It also justifies modeling
 them as independent functions even if instantiated by the same KDF.
 
 Future KEM instantiations MUST ensure that all internal invocations of
@@ -931,8 +931,8 @@ ensure this is by using an equal or similar prefixing scheme with
 an identifier different from "RFCXXXX ". Particular attention needs to
 be paid if the KEM directly invokes functions that are used internally
 in HPKE's Extract or Expand, such as Hash and HMAC in the case of HKDF.
-It MUST be ensured that inputs to these invokations cannot collide with
-inputs to the internal invokations of these functions inside Extract or
+It MUST be ensured that inputs to these invocations cannot collide with
+inputs to the internal invocations of these functions inside Extract or
 Expand. To avoid the latter, HPKE's KeySchedule uses Extract instead of
 Hash on the arbitrary-length inputs `info`, `pskID`, and `psk`.
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -479,6 +479,9 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
   context = concat(ciphersuite, mode, enc, pkRm,
                    pkSm, pskID_hash, info_hash)
 
+  if length(psk) > Nb then:
+    psk = Extract(0, concat("psk", psk))
+
   secret = Extract(psk, zz)
   key = Expand(secret, concat("key", context), Nk)
   nonce = Expand(secret, concat("nonce", context), Nn)
@@ -553,9 +556,18 @@ The primary differences from the base case are:
 * The PSK ID is added to the context string used as the `info` input
   to the KDF
 
-This mechanism is not suitable for use with a low-entropy password
-as the PSK.  A malicious recipient that does not possess the PSK can
-use decryption of a plaintext as an oracle for performing offline
+The PSK SHOULD be of length Nh bytes or longer, and SHOULD have
+Nh bytes of entropy or more. Using a PSK shorter than Nh bytes
+is permitted. A PSK that is longer than Nh bytes or has more than
+Nh bytes of entropy, respectively, does not increase the security
+level of HPKE, because only Nh bytes are extracted from the PSK and
+the KEM shared secret.
+
+HPKE is specified to use HKDF as key derivation function. HKDF is not
+designed to slow down dictionary attacks, see {{?RFC5869}}. Thus,
+HPKE's PSK mechanism is not suitable for use with a low-entropy
+password as the PSK. An adversary that does not possess the PSK can
+use decryption of an HPKE ciphertext as an oracle for performing
 dictionary attacks.
 
 ~~~~~

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -278,13 +278,13 @@ separation of calls as well as context binding:
 
 ~~~
 def LabeledExtract(salt, label, IKM):
-  labeled_IKM = concat("RFCXXXX ", label, IKM)
-  return Extract(salt, labeled_IKM)
+  labeledIKM = concat("RFCXXXX ", label, IKM)
+  return Extract(salt, labeledIKM)
 
 def LabeledExpand(PRK, label, info, L):
-  labeled_info = concat(encode_big_endian(L, 2),
+  labeledInfo = concat(encode_big_endian(L, 2),
                         "RFCXXXX ", label, info)
-  return Expand(PRK, labeled_info, L)
+  return Expand(PRK, labeledInfo, L)
 ~~~
 \[\[RFC editor: please change "RFCXXXX" to the correct number before publication.]]
 
@@ -310,9 +310,9 @@ following way, where `Group` denotes the Diffie-Hellman group and
 `KDF` the KDF:
 
 ~~~
-def ExtractAndExpand(dh, context_kem):
+def ExtractAndExpand(dh, kemContext):
   prk = LabeledExtract(0, "dh", dh)
-  return LabeledExpand(prk, "prk", context_kem, Nzz)
+  return LabeledExpand(prk, "prk", kemContext, Nzz)
 
 def Encap(pkR):
   skE, pkE = GenerateKeyPair()
@@ -320,9 +320,9 @@ def Encap(pkR):
   enc = Marshal(pkE)
 
   pkRm = Marshal(pkR)
-  context_kem = concat(enc, pkRm)
+  kemContext = concat(enc, pkRm)
 
-  zz = ExtractAndExpand(dh, context_kem)
+  zz = ExtractAndExpand(dh, kemContext)
   return zz, enc
 
 def Decap(enc, skR, pkR):
@@ -330,9 +330,9 @@ def Decap(enc, skR, pkR):
   dh = DH(skR, pkE)
 
   pkRm = Marshal(pkR)
-  context_kem = concat(enc, pkRm)
+  kemContext = concat(enc, pkRm)
 
-  zz = ExtractAndExpand(dh, context_kem)
+  zz = ExtractAndExpand(dh, kemContext)
   return zz, enc
 
 def AuthEncap(pkR, skS, pkS):
@@ -342,9 +342,9 @@ def AuthEncap(pkR, skS, pkS):
 
   pkRm = Marshal(pkR)
   pkSm = Marshal(pkS)
-  context_kem = concat(enc, pkRm, pkSm)
+  kemContext = concat(enc, pkRm, pkSm)
 
-  zz = ExtractAndExpand(dh, context_kem)
+  zz = ExtractAndExpand(dh, kemContext)
   return zz, enc
 
 def AuthDecap(enc, skR, pkR, pkS):
@@ -353,9 +353,9 @@ def AuthDecap(enc, skR, pkR, pkS):
 
   pkRm = Marshal(pkR)
   pkSm = Marshal(pkS)
-  context_kem = concat(enc, pkRm, pkSm)
+  kemContext = concat(enc, pkRm, pkSm)
 
-  zz = ExtractAndExpand(dh, context_kem)
+  zz = ExtractAndExpand(dh, kemContext)
   return zz, enc
 ~~~
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -249,14 +249,15 @@ HPKE variants rely on the following primitives:
   - Nenc: The length in bytes of an encapsulated key produced by this KEM
   - Npk: The length in bytes of an encoded public key for this KEM
 
-* A Key Derivation Function:
+* A Key Derivation Function (KDF):
   - Hash(m): Compute the cryptographic hash of input message `m`
   - Extract(salt, IKM): Extract a pseudorandom key of fixed length
     from input keying material `IKM` and an optional byte string
     `salt`
   - Expand(PRK, info, L): Expand a pseudorandom key `PRK` using
     optional string `info` into `L` bytes of output keying material
-  - Nh: The output size of the Hash and Extract functions in octets
+  - Nb: The block size of the Hash function in bytes
+  - Nh: The output size of the Hash and Extract functions in bytes
 
 * An AEAD encryption algorithm {{!RFC5116}}:
   - Seal(key, nonce, aad, pt): Encrypt and authenticate plaintext

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -278,12 +278,12 @@ separation of calls as well as context binding:
 
 ~~~
 def LabeledExtract(salt, label, IKM):
-  labeled_IKM = concat("RFC XXXX ", label, IKM)  
+  labeled_IKM = concat("RFCXXXX ", label, IKM)  
   return Extract(salt, labeled_IKM)
 
 def LabeledExpand(PRK, label, info, L):
   labeled_info = concat(encode_big_endian(L, 2),
-                        "RFC XXXX ", label, info)
+                        "RFCXXXX ", label, info)
   return Expand(PRK, labeled_info, L)
 ~~~
 \[\[RFC editor: please change "RFCXXXX" to the correct number before publication.]]
@@ -312,7 +312,7 @@ following way, where `Group` denotes the Diffie-Hellman group and
 
 ~~~
 def ExtractAndExpand(dh, context_kem):
-  prk = LabeledExtract_kem(0, "DHKEM", dh)
+  prk = LabeledExtract_kem(0, "dh", dh)
   return LabeledExpand_kem(prk, "prk", context_kem, Nzz)
 
 def Encap(pkR):
@@ -487,8 +487,7 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
                        encode_big_endian(aead_id, 2))
   pskID_hash = LabeledExtract(0, "pskID", pskID)
   info_hash = LabeledExtract(0, "info", info)
-  identifier = "RFCXXXX HPKE"
-  context = concat(identifier, ciphersuite, mode, enc, pkRm,
+  context = concat(ciphersuite, mode, enc, pkRm,
                    pkSm, pskID_hash, info_hash)
 
   if length(psk) > Nb then:
@@ -501,7 +500,6 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
 
   return Context(key, nonce, exporter_secret)
 ~~~~~
-\[\[RFC editor: please change "RFCXXXX" to the correct number before publication.]]
 
 Note that the context construction in the KeySchedule procedure is
 equivalent to serializing a structure of the following form in the
@@ -509,8 +507,6 @@ TLS presentation syntax:
 
 ~~~~~
 struct {
-    uint8 identifier[12] = "RFCXXXX HPKE";
-
     // Mode and algorithms
     uint16 kem_id;
     uint16 kdf_id;

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -900,9 +900,9 @@ designed to slow down dictionary attacks, see {{?RFC5869}}. Thus,
 HPKE's PSK mechanism is not suitable for use with a low-entropy
 password as the PSK: in scenarios in which the adversary knows the
 KEM shared secret zz, it can perform a dictionary attack on the PSK.
-The adversary can use different oracles to decide if a guess was good,
+The adversary can use different oracles to decide if a PSK guess was correct,
 depending on the scenario. First, on observation of an HPKE ciphertext,
-it can use decryption of the ciphertext as oracle. HPKE ciphertexts are
+the adversary can use decryption of the ciphertext as oracle. HPKE ciphertexts are
 created with an authenticated encryption scheme, which means decryption
 fails when using a wrong key. Second, the adversary can act as sender
 and create candidate HPKE ciphertexts. A recipient's behaviour can serve
@@ -911,13 +911,9 @@ Third, if an application does not use Seal to create HPKE ciphertexts
 but only the Export interface, the adversary could rely on other
 recipient behavior which is observably different when using a wrong key.
 
-Scenarios in which the adversary can know the KEM shared secret zz
+Scenarios in which the adversary knows the KEM shared secret zz
 depend on the KEM. In the case of DHKEM, it is enough if the adversary
-knows all private keys of one participant. In mode PSK, either knowledge
-of skR or skE is sufficient. If the adversary can act as sender, it does
-obviously know skE. In mode AuthPSK, either knowledge of skR or (skS and
-skE) is sufficient. Knowledge of skR is sufficient because
-Diffie-Hellman is subject to key-compromise impersonation.
+knows all private keys of one participant. 
 
 ## Domain Separation
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -473,16 +473,16 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
   ciphersuite = concat(encode_big_endian(kem_id, 2),
                        encode_big_endian(kdf_id, 2),
                        encode_big_endian(aead_id, 2))
-  label_hash = "RFCXXXX HPKE"
-  pskID_hash = Hash(concat(label_hash, pskID))
-  info_hash = Hash(concat(label_hash, info))
-  context = concat(ciphersuite, mode, enc, pkRm,
+  pskID_hash = Extract(0, concat("pskID", pskID))
+  info_hash = Extract(0, concat("info", info))
+  identifier = "RFCXXXX HPKE"
+  context = concat(identifier, ciphersuite, mode, enc, pkRm,
                    pkSm, pskID_hash, info_hash)
 
   if length(psk) > Nb then:
     psk = Extract(0, concat("psk", psk))
 
-  secret = Extract(psk, zz)
+  secret = Extract(psk, concat("zz", zz))
   key = Expand(secret, concat("key", context), Nk)
   nonce = Expand(secret, concat("nonce", context), Nn)
   exporter_secret = Expand(secret, concat("exp", context), Nh)
@@ -491,20 +491,19 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
 ~~~~~
 \[\[RFC editor: please change "RFCXXXX" to the correct number before publication.]]
 
-\[\[RFC editor: please change "RFCXXXX" to the correct number before
-publication.]]
-
 Note that the context construction in the KeySchedule procedure is
 equivalent to serializing a structure of the following form in the
 TLS presentation syntax:
 
 ~~~~~
 struct {
+    uint8 identifier[12];
+
     // Mode and algorithms
-    uint8 mode;
     uint16 kem_id;
     uint16 kdf_id;
     uint16 aead_id;
+    uint8 mode;
 
     // Public inputs to this key exchange
     opaque enc[Nenc];

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -360,8 +360,12 @@ def AuthDecap(enc, skR, pkR, pkS):
 ~~~
 
 The KDF used in DHKEM can be equal to or different from the KDF used
-in the remainder of HPKE depending on the chosen variant. See
-{{domain-separation}} for a security-related discussion.
+in the remainder of HPKE, depending on the chosen variant.
+Implementations MUST make sure to use the constants (Nh) and function
+calls (LabeledExtract, LabeledExpand) of the appropriate KDF when
+implementing DHKEM. See {{kdf-choice}} for a comment on the choice of
+a KDF for the remainder of HPKE, and {{domain-separation}} for the
+rationale of the labels.
 
 For the variants of DHKEM defined in this document, Ndh is equal to Npk,
 and the output length of the KDF's Hash and Extract functions is Nzz
@@ -889,6 +893,13 @@ In addition, both {{CS01}} and {{HPKEAnalysis}} are premised on classical
 security models and assumptions, and do not consider attackers capable of quantum
 computation. A full proof of post-quantum security would need to take this
 difference into account, in addition to simply using a post-quantum KEM.
+
+## Choosing a KDF When Combining With a KEM {#kdf-choice}
+
+The choice of the KDF for the remainder of HPKE should be made based on
+the security level provided by the KEM and, if applicable, by the PSK.
+The KDF SHOULD have at least have the security level of the KEM and
+SHOULD at least have the security level provided by the PSK.
 
 ## Pre-Shared Key Recommendations {#security-psk}
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -899,17 +899,11 @@ HPKE is specified to use HKDF as key derivation function. HKDF is not
 designed to slow down dictionary attacks, see {{?RFC5869}}. Thus,
 HPKE's PSK mechanism is not suitable for use with a low-entropy
 password as the PSK: in scenarios in which the adversary knows the
-KEM shared secret zz, it can perform a dictionary attack on the PSK.
-The adversary can use different oracles to decide if a PSK guess was correct,
-depending on the scenario. First, on observation of an HPKE ciphertext,
-the adversary can use decryption of the ciphertext as oracle. HPKE ciphertexts are
-created with an authenticated encryption scheme, which means decryption
-fails when using a wrong key. Second, the adversary can act as sender
-and create candidate HPKE ciphertexts. A recipient's behaviour can serve
-as oracle, e.g. if an error message implies that a wrong PSK was used.
-Third, if an application does not use Seal to create HPKE ciphertexts
-but only the Export interface, the adversary could rely on other
-recipient behavior which is observably different when using a wrong key.
+KEM shared secret zz and has access to an oracle for decryption success
+of an HPKE ciphertext, it can perform a dictionary attack on the PSK.
+If an application does not use Seal to create HPKE ciphertexts but only
+the Export interface, the adversary can rely on other recipient behavior
+which is observably different when using a wrong key.
 
 Scenarios in which the adversary knows the KEM shared secret zz
 depend on the KEM. In the case of DHKEM, it is enough if the adversary


### PR DESCRIPTION
The isolated DHKEM cannot be proven IND-CCA-secure as it is: In the current Encap, nothing is done with the result of the DH operation, `zz`. This means there is nowhere where the GDH assumption can be applied, as for this we need a comparison of a value with `g^ab` in the game, like `g^c = g^ab`, which we can then change in a game hop to `false`.

This is not a problem when looking at HPKE as a whole, because `zz` is fed into Extract which we model as a random oracle. For DHKEM isolated, this problem can be fixed by feeding the Diffie-Hellman shared secret through another random oracle before returning the result as `zz`.

The hash functions suggested in this pull request are chosen to correspond to the security level of the elliptic curve DH, respectively. If users of HPKE want to use only one hash function, then they need to choose the KDF depending on the used DHKEM. Specifying each DHKEM for multiple (i.e. different output size) hash functions seems overkill and like sending wrong signals about the security level of DHKEM.

Regarding random oracle cloning: By introducing another call to a random oracle, which might be implemented by the same hash function, this becomes now more relevant than before. I think we need to make sure that Hash' and the calls to Hash inside HMAC are independent, to be able to use the indifferentiability theorem on SHAxxx. I looked at the input domains of these two calls for SHA256, SHA384, and SHA512 and they are indeed _already disjoint_ by their lengths. An open question is if we need to do something about the Hash calls `Hash(pskID)` and `Hash(info)` that we model as collision resistant. I like to discuss this with Bruno and/or Karthik before proceeding.

This pull request is to keep you in the loop, please feel free to provide preliminary feedback.