### PR TITLE
Reference revision 3 of NIST.SP.800-56A (and insert newlines to make .md more readable on Github)

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -34,6 +34,7 @@ informative:
         ins: Ronald Cramer
       -
         ins: Victor Shoup
+
   GAP:
     title: The Gap-Problems - a New Class of Problems for the Security of Cryptographic Schemes
     target: https://link.springer.com/content/pdf/10.1007/3-540-44586-2_8.pdf
@@ -45,6 +46,7 @@ informative:
         ins: David Pointcheval
     seriesinfo:
       ISBN: 978-3-540-44586-9
+
   ANSI:
     title: Public Key Cryptography for the Financial Services Industry -- Key Agreement and Key Transport Using Elliptic Curve Cryptography
     date: 2001
@@ -52,6 +54,7 @@ informative:
       -
         ins:
         org: American National Standards Institute
+
   IEEE:
     title: IEEE 1363a, Standard Specifications for Public Key Cryptography - Amendment 1 -- Additional Techniques
     date: 2004
@@ -59,6 +62,7 @@ informative:
       -
         ins:
         org: Institute of Electrical and Electronics Engineers
+
   ISO:
     title: ISO/IEC 18033-2, Information Technology - Security Techniques - Encryption Algorithms - Part 2 -- Asymmetric Ciphers
     date: 2006
@@ -135,7 +139,9 @@ informative:
     date: 2019
 
   keyagreement: DOI.10.6028/NIST.SP.800-56Ar2
+
   NISTCurves: DOI.10.6028/NIST.FIPS.186-4
+
   GCM: DOI.10.6028/NIST.SP.800-38D
 
   fiveG:

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -138,7 +138,7 @@ informative:
     target: https://github.com/cfrg/draft-irtf-cfrg-hpke/blob/1e98830311b27f9af00787c16e2c5ac43abeadfb/test-vectors.json
     date: 2019
 
-  keyagreement: DOI.10.6028/NIST.SP.800-56Ar2
+  keyagreement: DOI.10.6028/NIST.SP.800-56Ar3
 
   NISTCurves: DOI.10.6028/NIST.FIPS.186-4
 


### PR DESCRIPTION
There is revision 3 of NIST.SP.800-56A since a while. Is there a specific reason why revision 2 is referenced? If not then this pull request proposes to change the reference to revision 3.

I did /not/ check if, for example, broadly-deployed implementations are not yet implementing revision 3.