### PR TITLE
Clarify key validation, as it is different for NIST curves and Curve25519/448

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -704,12 +704,13 @@ def OpenAuthPSK(enc, skR, info, aad, ct, psk, pskID, pkS):
 For the NIST curves P-256, P-384 and P-521, the Marshal function of the
 DH scheme produces the normal (non-compressed) representation of the
 public key, according to {{SECG}}.  When these curves are used, senders
-and recipients MUST perform a full public-key validation as defined
-in {{keyagreement}}, which includes validating that a public key is on
-the curve and part of the correct prime-order subgroup.  The sender
-MUST validate the recipient's public key `pkR`.  The recipient MUST
-validate the ephemeral public key `pkE`.  In authenticated modes, the
-recipient MUST validate the sender's static public key `pkS`.
+and recipients MUST perform full public-key validation on all public
+key inputs as defined in {{keyagreement}}, which includes validating
+that a public key is on the curve and part of the correct prime-order
+subgroup.  The sender MUST validate the recipient's public key `pkR`.
+The recipient MUST validate the ephemeral public key `pkE`. In
+authenticated modes, the recipient MUST validate the sender's static
+public key `pkS`.
 
 For the CFRG curves Curve25519 and Curve448, the Marshal function is
 the identity function, since these curves already use fixed-length

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -715,7 +715,7 @@ public key `pkS`.
 For the CFRG curves Curve25519 and Curve448, the Marshal function is
 the identity function, since these curves already use fixed-length
 byte strings for public keys. When these curves are used, validation of
-public keys is not necessary. Implementations MAY check whether the
+public keys is not necessary. Implementations MUST check whether the
 shared secret is the all-zero value and abort if so, as described in
 {{?RFC7748}}.
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -378,8 +378,7 @@ context. The key schedule inputs are as follows:
 * `pkSm` - The sender's encoded public key (optional; default
   value `zero(Npk)`)
 
-Senders and recipients MUST implement the validations of KEM inputs
-and outputs imposed by the employed KEM algorithm, as described
+Senders and recipients MUST validate KEM inputs and outputs as described
 in {{kem-ids}}.
 
 The `psk` and `pskID` fields MUST appear together or not at all.

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -316,6 +316,10 @@ curves referenced in {#ciphersuites} are as follows:
 * Curve25519: The standard 32-byte representation of the public key
 * Curve448: The standard 56-byte representation of the public key
 
+Implementations MUST adhere to the validation processes imposed on
+received values by the employed KEM algorithm, as described
+in {{kem-ids}}.
+
 # Hybrid Public Key Encryption
 
 In this section, we define a few HPKE variants.  All variants take a
@@ -375,12 +379,9 @@ context. The key schedule inputs are as follows:
 * `pkSm` - The sender's encoded public key (optional; default
   value `zero(Npk)`)
 
-Senders and receivers MUST validate public keys for correctness.
-For example, when using a DH-based KEM, the sender should check
-that the receiver's key `pkR` is valid, i.e., a point on the
-corresponding curve and part of the correct prime-order subgroup.
-Similarly, the receiver should check that the sender's ephemeral
-key `pkE` is valid. See {{kem-ids}} for discussion related to other KEMs.
+Senders and receivers MUST adhere to the validation processes imposed
+on received values by the employed KEM algorithm, as described
+in {{kem-ids}}.
 
 The `psk` and `pskID` fields MUST appear together or not at all.
 That is, if a non-default value is provided for one of them, then
@@ -706,12 +707,17 @@ For the NIST curves P-256 and P-521, the Marshal function of the DH
 scheme produces the normal (non-compressed) representation of the
 public key, according to {{SECG}}.  When these curves are used, the
 recipient of an HPKE ciphertext MUST validate that the ephemeral public
-key `pkE` is on the curve.  The relevant validation procedures are
+key `pkE` is on the curve and part of the correct prime-order subgroup.
+For authenticated modes the same validation MUST be done for  the static
+public key `pkS`.  The relevant full public-key validation procedure is
 defined in {{keyagreement}}.
 
 For the CFRG curves Curve25519 and Curve448, the Marshal function is
 the identity function, since these curves already use fixed-length
-byte strings for public keys.
+byte strings for public keys. When these curves are used, validation of
+public keys is not necessary. Implementations MAY check whether the
+shared secret is the all-zero value and abort if so, as described in
+{{?RFC7748}}.
 
 ## Key Derivation Functions (KDFs) {#kdf-ids}
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -316,8 +316,8 @@ curves referenced in {#ciphersuites} are as follows:
 * Curve25519: The standard 32-byte representation of the public key
 * Curve448: The standard 56-byte representation of the public key
 
-Implementations MUST adhere to the validation processes imposed on
-received values by the employed KEM algorithm, as described
+Senders and recipients MUST implement the validations of KEM inputs
+and outputs imposed by the employed KEM algorithm, as described
 in {{kem-ids}}.
 
 # Hybrid Public Key Encryption
@@ -379,8 +379,8 @@ context. The key schedule inputs are as follows:
 * `pkSm` - The sender's encoded public key (optional; default
   value `zero(Npk)`)
 
-Senders and receivers MUST adhere to the validation processes imposed
-on received values by the employed KEM algorithm, as described
+Senders and recipients MUST implement the validations of KEM inputs
+and outputs imposed by the employed KEM algorithm, as described
 in {{kem-ids}}.
 
 The `psk` and `pskID` fields MUST appear together or not at all.
@@ -703,14 +703,15 @@ def OpenAuthPSK(enc, skR, info, aad, ct, psk, pskID, pkS):
 | 0x0020 | DHKEM(Curve25519) | 32   | 32  | {{?RFC7748}}   |
 | 0x0021 | DHKEM(Curve448)   | 56   | 56  | {{?RFC7748}}   |
 
-For the NIST curves P-256 and P-521, the Marshal function of the DH
-scheme produces the normal (non-compressed) representation of the
-public key, according to {{SECG}}.  When these curves are used, the
-recipient of an HPKE ciphertext MUST validate that the ephemeral public
-key `pkE` is on the curve and part of the correct prime-order subgroup.
-For authenticated modes the same validation MUST be done for the static
-public key `pkS`.  The relevant full public-key validation procedure is
-defined in {{keyagreement}}.
+For the NIST curves P-256, P-384 and P-521, the Marshal function of the
+DH scheme produces the normal (non-compressed) representation of the
+public key, according to {{SECG}}.  When these curves are used, senders
+and recipients MUST perform a full public-key validation as defined
+in {{keyagreement}}, which includes validating that a public key is on
+the curve and part of the correct prime-order subgroup.  The sender
+MUST validate the recipient's public key `pkR`.  The recipient MUST
+validate the ephemeral public key `pkE`.  In authenticated modes, the
+recipient MUST validate the sender's static public key `pkS`.
 
 For the CFRG curves Curve25519 and Curve448, the Marshal function is
 the identity function, since these curves already use fixed-length

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -316,8 +316,7 @@ curves referenced in {#ciphersuites} are as follows:
 * Curve25519: The standard 32-byte representation of the public key
 * Curve448: The standard 56-byte representation of the public key
 
-Senders and recipients MUST implement the validations of KEM inputs
-and outputs imposed by the employed KEM algorithm, as described
+Senders and recipients MUST validate KEM inputs and outputs as described
 in {{kem-ids}}.
 
 # Hybrid Public Key Encryption

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -701,22 +701,33 @@ def OpenAuthPSK(enc, skR, info, aad, ct, psk, pskID, pkS):
 | 0x0020 | DHKEM(Curve25519) | 32   | 32  | {{?RFC7748}}   |
 | 0x0021 | DHKEM(Curve448)   | 56   | 56  | {{?RFC7748}}   |
 
+### Marshal
+
 For the NIST curves P-256, P-384 and P-521, the Marshal function of the
 DH scheme produces the normal (non-compressed) representation of the
-public key, according to {{SECG}}.  When these curves are used, senders
-and recipients MUST perform full public-key validation on all public
-key inputs as defined in {{keyagreement}}, which includes validating
-that a public key is on the curve and part of the correct prime-order
-subgroup.  The sender MUST validate the recipient's public key `pkR`.
-The recipient MUST validate the ephemeral public key `pkE`. In
-authenticated modes, the recipient MUST validate the sender's static
-public key `pkS`.
+public key, according to {{SECG}}.
 
 For the CFRG curves Curve25519 and Curve448, the Marshal function is
 the identity function, since these curves already use fixed-length
-byte strings for public keys. When these curves are used, validation of
-public keys is not necessary. Implementations MUST check whether the
-shared secret is the all-zero value and abort if so, as described in
+byte strings for public keys.
+
+### Validation of Inputs and Outputs
+
+The following public keys are subject to validation if the curve
+requires public key validation: the sender MUST validate the recipient's
+public key `pkR`; the recipient MUST validate the ephemeral public key
+`pkE`; in authenticated modes, the recipient MUST validate the sender's
+static public key `pkS`.
+
+For the NIST curves P-256, P-384 and P-521, senders and recipients
+MUST perform full public-key validation on all public key inputs as
+defined in {{keyagreement}}, which includes validating that a public
+key is on the curve and part of the correct prime-order subgroup.
+Validation of the computed shared secret is not necessary.
+
+For the CFRG curves Curve25519 and Curve448, validation of public keys
+is required. Senders and recipients MUST check whether the shared
+secret is the all-zero value and abort if so, as described in
 {{?RFC7748}}.
 
 ## Key Derivation Functions (KDFs) {#kdf-ids}

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -708,7 +708,7 @@ scheme produces the normal (non-compressed) representation of the
 public key, according to {{SECG}}.  When these curves are used, the
 recipient of an HPKE ciphertext MUST validate that the ephemeral public
 key `pkE` is on the curve and part of the correct prime-order subgroup.
-For authenticated modes the same validation MUST be done for  the static
+For authenticated modes the same validation MUST be done for the static
 public key `pkS`.  The relevant full public-key validation procedure is
 defined in {{keyagreement}}.
 


### PR DESCRIPTION
Points to discuss:

- I made this proposal with “MAY check whether the shared secret is the all-zero value” for Curve25519/448 because this how the RFC states it. We can discuss if HPKE should be more opinionated on it
- I shortened the discussion of validation in Section “Creating the Encryption Context” and instead link to {{kem-ids}}. I added the more or less same paragraph to Section “DH-Based KEM” because that is where DHKEM is actually defined. We can discuss if one of the two places is enough to mention validation.