### PR TITLE
Clarified endianness of ciphersuite serialization

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -430,7 +430,9 @@ def KeySchedule(mode, pkR, zz, enc, info, psk, pskID, pkSm):
 
   pkRm = Marshal(pkR)
   identifier = "RFCXXXX"
-  ciphersuite = concat(kem_id, kdf_id, aead_id)
+  ciphersuite = concat(encode_big_endian(kem_id, 2),
+                       encode_big_endian(kdf_id, 2),
+                       encode_big_endian(aead_id, 2))
   pskID_hash = Hash(pskID)
   info_hash = Hash(info)
   context = concat(identifier, ciphersuite, mode, enc, pkRm,


### PR DESCRIPTION
This was an ambiguity. `concat` is only defined for bytestrings, but the ciphersuite identifiers are all u16. Since everything else is big-endian, it makes sense for this to be big-endian as well.