### PR TITLE
Clarification on validation for NIST curves

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -731,7 +731,9 @@ For the NIST curves P-256, P-384 and P-521, senders and recipients
 MUST perform full public-key validation on all public key inputs as
 defined in {{keyagreement}}, which includes validating that a public
 key is on the curve and part of the correct prime-order subgroup.
-Validation of the computed shared secret is not necessary.
+Additionally, one of the following checks MUST be ensured: the scalar
+given as input to DH is in the interval [1, n-1] where n is the prime
+order of the subgroup; the result of DH is not the point at infinity.
 
 For the CFRG curves Curve25519 and Curve448, validation of public keys
 is not required. Senders and recipients MUST check whether the shared


### PR DESCRIPTION
Implicitly, it might be assumed that the scalar (private key) is honestly generated and thus ensured to be in the correct interval. This proposed change makes this more explicit.