### PR TITLE
Simplify definition of the len function

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -211,13 +211,12 @@ operations, roles, and behaviors of HPKE:
 - `(skX, pkX)`: A KEM key pair used in role X; `skX` is the private
   key and `pkX` is the public key
 - `pk(skX)`: The public key corresponding to private key `skX`
-- `len(x)`: The length of the byte string `x`, expressed as a
-  two-byte unsigned integer in network (big-endian) byte order
+- `len(x)`: The length of the byte string `x` in bytes
 - `encode_big_endian(x, n)`: An byte string encoding the integer
   value `x` as an n-byte big-endian value
 - `concat(x0, ..., xN)`: Concatenation of byte strings.
   `concat(0x01, 0x0203, 0x040506) = 0x010203040506`
-- `zero(n)`: An all-zero byte string of length `n`. `zero(4) =
+- `zero(n)`: An all-zero byte string of length `n` bytes. `zero(4) =
   0x00000000`
 - `xor(a,b)`: XOR of byte strings; `xor(0xF0F0, 0x1234) = 0xE2C4`.
   It is an error to call this function with two arguments of unequal
@@ -630,7 +629,7 @@ field to wrap, then the implementation MUST return an error.
 
 ~~~~~
 def Context.Nonce(seq):
-  encSeq = encode_big_endian(seq, len(self.nonce))
+  encSeq = encode_big_endian(seq, Nn)
   return xor(self.nonce, encSeq)
 
 def Context.IncrementSeq():


### PR DESCRIPTION
- We know that the length of the nonce is `Nn` because it was created with `Expand(…, …, Nn)`, so we don't need a dynamic computation of it.
- For `len` and `zero`, clarify that the length is in bytes

Now the _only_ use of `len` is when we compare the length of the PSK to `Nb` (if #50 gets merged as is):
```
  if len(psk) > Nb then:
    psk = LabeledExtract(0, "psk", psk)
```

I suggest that in the definition of `len` we remove the part that details that the result is `expressed as two-byte unsigned integer in network (big-endian) byte order`. Arguments pro:
- little-endian is the dominant ordering for processor architectures. This would mean that most implementations must do extra work to have len return big-endian, just to notice then that Nb is little-endian and that they cannot compare a big-endian value to a little-endian one.
- it arbitrarily limits the PSK to 2^16 bytes
- we don't specify how implementations have to store local integer values like `Nn`, `Nh`, etc so it seems overly specific to impose a certain encoding for the result of an internal function