### PR TITLE
Only hash PSK in the PSK and AuthPSK modes

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -508,7 +508,8 @@ def KeySchedule(mode, zz, info, psk, pskID, pkSm):
   info_hash = LabeledExtract(zero(Nh), "info", info)
   context = concat(ciphersuite, mode, pskID_hash, info_hash)
 
-  psk = LabeledExtract(zero(Nh), "psk", psk)
+  if mode == mode_psk or mode == mode_auth_psk:
+    psk = LabeledExtract(zero(Nh), "psk", psk)
 
   secret = LabeledExtract(psk, "zz", zz)
   key = LabeledExpand(secret, "key", context, Nk)


### PR DESCRIPTION
In the Base and Auth modes, the only PSK ever used is the default psk, which is constant and all zero. Instead of transforming the Nh bytes default psk into another constant of length Nh bytes, using LabeledExtract, we can just not transform the default psk at all and use it directly. This removes the performance penalty for non-psk modes.

An alternative would be that implementations pre-computed the transformed default psk value. This seems a stretch to me, as transforming the default psk does not buy anything in terms of provable security. If we assume that implementations specialize for one particular HPKE mode anyway, it also does not buy much in terms of reducing probability of implementation mistakes.