### PR TITLE
Removed remaining instances of LabeledExtract(zero(Nh), ...)

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -501,11 +501,11 @@ def KeySchedule(mode, zz, info, psk, pskID):
   ciphersuite = concat(encode_big_endian(kem_id, 2),
                        encode_big_endian(kdf_id, 2),
                        encode_big_endian(aead_id, 2))
-  pskID_hash = LabeledExtract(zero(Nh), "pskID_hash", pskID)
-  info_hash = LabeledExtract(zero(Nh), "info", info)
+  pskID_hash = LabeledExtract(zero(0), "pskID_hash", pskID)
+  info_hash = LabeledExtract(zero(0), "info", info)
   context = concat(ciphersuite, mode, pskID_hash, info_hash)
 
-  psk_hash = LabeledExtract(zero(Nh), "psk_hash", psk)
+  psk_hash = LabeledExtract(zero(0), "psk_hash", psk)
 
   secret = LabeledExtract(psk_hash, "zz", zz)
   key = LabeledExpand(secret, "key", context, Nk)


### PR DESCRIPTION
By the same reasoning as https://github.com/cfrg/draft-irtf-cfrg-hpke/pull/81, we shouldn't use `zero(Nh)` as a salt for `LabeledExtract`.