### PR TITLE
Change default_psk to be the empty byte string, Remove unused default_pkSm

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -517,7 +517,6 @@ AEAD `aead_id` 2-byte code points, are assumed implicit from the
 implementation and not passed as parameters.
 
 ~~~~~
-default_pkSm = zero(Npk)
 default_psk = zero(Nh)
 default_pskID = zero(0)
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -517,7 +517,7 @@ AEAD `aead_id` 2-byte code points, are assumed implicit from the
 implementation and not passed as parameters.
 
 ~~~~~
-default_psk = zero(Nh)
+default_psk = zero(0)
 default_pskID = zero(0)
 
 def VerifyPSKInputs(mode, psk, pskID):


### PR DESCRIPTION
Changes the default_psk to be the empty string, i.e. zero(0), instead of zero(Nh).

This makes implementations easier, because then, in PSK and AuthPSK mode, to check that the psk provided is not equal to the default_psk, it will be enough to check that the psk is strictly longer than 0 bytes, instead of comparing Nh bytes.

TODO: change VerifyPSKInputs to check the length, instead of using `!=`?