### PR TITLE
Add section on input limits for psk, pskID, info, exporter_context

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -913,7 +913,7 @@ for the KDFs defined in this document, as inclusive bounds in bytes:
 | exporter_context | 2^{61} - 111 | 2^{125} - 191 | 2^{125} - 207 |
 
 The values for `psk`, `pskID`, and `info` which are inputs to
-`LabeledExtract` were computed with the following equation:
+`LabeledExtract` were computed with the following expression:
 
 ~~~
 max_size_hash_input - Nb - size_label_rfcXXXX - size_label

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -929,7 +929,7 @@ max_size_hash_input - Nb - Nh - size_label_rfcXXXX - size_input_label - 2 - 1
 In these equations, `max_size_hash_input` is the maximum input length
 of the underlying hash function in bytes, `Nb` is the block size of the
 underlying hash function in bytes, `size_label_rfcXXXX` is the size
-of "RFCXXXX " in bytes and equals 8, and `size_label` is the size of
+of "RFCXXXX " in bytes and equals 8, and `size_input_label` is the size of
 the label used as parameter to `LabeledExtract` or `LabeledExpand`.
 
 \[\[RFC editor: please change "RFCXXXX" to the correct number before publication.]]

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -900,7 +900,8 @@ This document defines `LabeledExtract` and `LabeledExpand` based on the
 KDFs listed above. These functions add prefixes to their respective
 inputs `IKM` and `info` before calling the KDF's Extract and Expand
 functions. This leads to a reduction of the maximum input length that
-is available for the inputs `psk`, `pskID`, `info`, `exporter_context`.
+is available for the inputs `psk`, `pskID`, `info`, `exporter_context`,
+the variable-length parameters provided by HPKE applications.
 The following table lists the maximum allowed lengths of these fields
 for the KDFs defined in this document, as inclusive bounds in bytes:
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -754,7 +754,7 @@ function.
 
 The `exporter_context` field has a maximum length that depends on the KDF
 itself, on the definition of `LabeledExpand`, and on the constant labels
-used together with them. See {{kdf-input-length}} for exact limits on this length.
+used together with them. See {{kdf-input-length}} for precise limits on this length.
 
 ~~~~~
 def Context.Export(exporter_context, L):
@@ -912,6 +912,12 @@ for the KDFs defined in this document, as inclusive bounds in bytes:
 | info             | 2^{61} - 82  | 2^{125} - 146 | 2^{125} - 146 |
 | exporter_context | 2^{61} - 111 | 2^{125} - 191 | 2^{125} - 207 |
 
+This shows that the limits are only marginally smaller than the maximum
+input length of the underlying hash function; these limits are large and
+unlikely to be reached in practical applications. Future specifications
+which define new KDFs MUST specify bounds for these variable-length
+parameters.
+ 
 The values for `psk`, `pskID`, and `info` which are inputs to
 `LabeledExtract` were computed with the following expression:
 
@@ -929,8 +935,8 @@ max_size_hash_input - Nb - Nh - size_label_rfcXXXX - size_input_label - 2 - 1
 In these equations, `max_size_hash_input` is the maximum input length
 of the underlying hash function in bytes, `Nb` is the block size of the
 underlying hash function in bytes, `size_label_rfcXXXX` is the size
-of "RFCXXXX " in bytes and equals 8, and `size_input_label` is the size of
-the label used as parameter to `LabeledExtract` or `LabeledExpand`.
+of "RFCXXXX " in bytes and equals 8, and `size_input_label` is the size
+of the label used as parameter to `LabeledExtract` or `LabeledExpand`.
 
 \[\[RFC editor: please change "RFCXXXX" to the correct number before publication.]]
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -902,7 +902,7 @@ inputs `IKM` and `info` before calling the KDF's Extract and Expand
 functions. This leads to a reduction of the maximum input length that
 is available for the inputs `psk`, `pskID`, `info`, `exporter_context`.
 The following table lists the maximum allowed lengths of these fields
-for the KDFs defined in this document, in bytes:
+for the KDFs defined in this document, as inclusive bounds in bytes:
 
 | Input            | HKDF-SHA256  | HKDF-SHA384   | HKDF-SHA512   |
 |:-----------------|:-------------|:--------------|:--------------|

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -923,7 +923,7 @@ The value for `exporter_context` which is an input to `LabeledExpand`
 was computed with the following expression:
 
 ~~~
-max_size_hash_input - Nb - Nh - size_label_rfcXXXX - size_label - 2 - 1
+max_size_hash_input - Nb - Nh - size_label_rfcXXXX - size_input_label - 2 - 1
 ~~~
 
 In these equations, `max_size_hash_input` is the maximum input length

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -916,11 +916,11 @@ The values for `psk`, `pskID`, and `info` which are inputs to
 `LabeledExtract` were computed with the following expression:
 
 ~~~
-max_size_hash_input - Nb - size_label_rfcXXXX - size_label
+max_size_hash_input - Nb - size_label_rfcXXXX - size_input_label
 ~~~
 
 The value for `exporter_context` which is an input to `LabeledExpand`
-was computed with the following equation:
+was computed with the following expression:
 
 ~~~
 max_size_hash_input - Nb - Nh - size_label_rfcXXXX - size_label - 2 - 1

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -754,7 +754,7 @@ function.
 
 The `exporter_context` field has a maximum length that depends on the KDF
 itself, on the definition of `LabeledExpand`, and on the constant labels
-used together with them. See {{kdf-input-length}} for exact indications.
+used together with them. See {{kdf-input-length}} for exact limits on this length.
 
 ~~~~~
 def Context.Export(exporter_context, L):

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -506,7 +506,7 @@ the other MUST be set to a non-default value.
 The `psk`, `pskID`, and `info` fields have maximum lengths that depend
 on the KDF itself, on the definition of `LabeledExtract`, and on the
 constant labels used together with them. See {{kdf-input-length}} for
-exact indications.
+precise limits on these lengths.
 
 The key and nonce computed by this algorithm have the property that
 they are only known to the holder of the recipient private key, and


### PR DESCRIPTION
This adds concrete upper inclusive bounds for psk, pskID, info, and exporter_context that depend on the hash functions maximum input sizes and the constant labels we use in HPKE.

Computations are documented in https://gist.github.com/blipp/9c748499b6216e9cdca75d24c5297657.

The F* spec confirms that these bounds go along with the limits of the KDFs and underlying hash functions, see [here](https://github.com/project-everest/hacl-star/blob/e645526214a9bb4133f6f46521271e8fda5c2d99/specs/Spec.Agile.HPKE.fsti#L264) and [here](https://github.com/project-everest/hacl-star/blob/e645526214a9bb4133f6f46521271e8fda5c2d99/specs/Spec.Agile.HPKE.fsti#L300).