### PR TITLE
Replace "desc" with I2OSP(kem_id, 2).

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -836,7 +836,7 @@ rejection sampling over field elements:
 
 ~~~
 def DeriveKeyPair(ikm):
-  prk = LabeledExtract(zero(0), desc, ikm)
+  prk = LabeledExtract(zero(0), I2OSP(kem_id, 2), ikm)
   sk = 0
   counter = 1
   while sk == 0 or sk >= order:
@@ -848,21 +848,18 @@ def DeriveKeyPair(ikm):
   return (sk, pk(sk))
 ~~~
 
-where `desc` is "p-256", "p-384", or "p-521", depending on the curve being
-used; `order` is the order of the curve being used (this can be found in
-section D.1.2 of {{NISTCurves}}); and `bitmask` is defined to be 0xFF for P-256
+where `order` is the order of the curve being used (this can be found in
+section D.1.2 of {{NISTCurves}}), and `bitmask` is defined to be 0xFF for P-256
 and P-384, and 0x01 for P-521.
 
 For X25519 and X448, the DeriveKeyPair function applies a KDF to the input:
 
 ~~~
 def DeriveKeyPair(ikm):
-  prk = LabeledExtract(zero(0), desc, ikm)
+  prk = LabeledExtract(zero(0), I2OSP(kem_id, 2), ikm)
   sk = Expand(prk, zero(0), Nsk)
   return (sk, pk(sk))
 ~~~
-
-where `desc` is "x25519" or "x448", depending on the curve being used.
 
 ### Validation of Inputs and Outputs {#validation}
 


### PR DESCRIPTION
cc @rozbb 