### PR TITLE
Use LabeledExpand inside DeriveKeyPair

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -849,7 +849,7 @@ rejection sampling over field elements:
 def DeriveKeyPair(ikm):
   dkp_prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dkp_prk"), ikm)
   sk = 0
-  counter = 1
+  counter = 0
   while sk == 0 or sk >= order:
     if counter > 255:
       raise DeriveKeyPairError

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -847,11 +847,11 @@ rejection sampling over field elements:
 
 ~~~
 def DeriveKeyPair(ikm):
-  prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dkp:prk"), ikm)
+  dkp_prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dkp_prk"), ikm)
   sk = 0
   counter = 1
   while sk == 0 or sk >= order:
-    bytes = LabeledExpand(prk, "candidate", I2OSP(counter, 1), Nsk)
+    bytes = LabeledExpand(dkp_prk, "candidate", I2OSP(counter, 1), Nsk)
     bytes[0] = bytes[0] & bitmask
     sk = OS2IP(bytes)
     counter = counter + 1
@@ -866,8 +866,8 @@ For X25519 and X448, the DeriveKeyPair function applies a KDF to the input:
 
 ~~~
 def DeriveKeyPair(ikm):
-  prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dkp:prk"), ikm)
-  sk = LabeledExpand(prk, "sk", zero(0), Nsk)
+  dkp_prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dkp_prk"), ikm)
+  sk = LabeledExpand(dkp_prk, "sk", zero(0), Nsk)
   return (sk, pk(sk))
 ~~~
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -367,8 +367,8 @@ function specification for DHKEMs defined in this document.
 
 ~~~
 def ExtractAndExpand(dh, kemContext):
-  prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dh"), dh)
-  return LabeledExpand(prk, concat(I2OSP(kem_id, 2), "prk"), kemContext, Nzz)
+  prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "prk"), dh)
+  return LabeledExpand(prk, concat(I2OSP(kem_id, 2), "zz"), kemContext, Nzz)
 
 def Encap(pkR):
   skE, pkE = DeriveKeyPair(random(Nsk))

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -851,8 +851,7 @@ def DeriveKeyPair(ikm):
   sk = 0
   counter = 1
   while sk == 0 or sk >= order:
-    label = concat("candidate ", I2OSP(counter, 1))
-    bytes = Expand(prk, label, Nsk)
+    bytes = LabeledExpand(prk, "candidate", I2OSP(counter, 1), Nsk)
     bytes[0] = bytes[0] & bitmask
     sk = OS2IP(bytes)
     counter = counter + 1

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -863,7 +863,7 @@ def DeriveKeyPair(ikm):
 where `order` is the order of the curve being used (this can be found in
 section D.1.2 of {{NISTCurves}}), and `bitmask` is defined to be 0xFF for P-256
 and P-384, and 0x01 for P-521. The likelihood of DeriveKeyPair failing
-with DeriveKeyPairError is 2^(-8160).
+with DeriveKeyPairError depends on the group, but is negligible.
 
 For X25519 and X448, the DeriveKeyPair function applies a KDF to the input:
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -367,8 +367,8 @@ function specification for DHKEMs defined in this document.
 
 ~~~
 def ExtractAndExpand(dh, kemContext):
-  prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "prk"), dh)
-  return LabeledExpand(prk, concat(I2OSP(kem_id, 2), "zz"), kemContext, Nzz)
+  eae_prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "eae_prk"), dh)
+  return LabeledExpand(eae_prk, concat(I2OSP(kem_id, 2), "zz"), kemContext, Nzz)
 
 def Encap(pkR):
   skE, pkE = DeriveKeyPair(random(Nsk))

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -847,7 +847,7 @@ rejection sampling over field elements:
 
 ~~~
 def DeriveKeyPair(ikm):
-  prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dkp_prk"), ikm)
+  prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dkp:prk"), ikm)
   sk = 0
   counter = 1
   while sk == 0 or sk >= order:
@@ -866,7 +866,7 @@ For X25519 and X448, the DeriveKeyPair function applies a KDF to the input:
 
 ~~~
 def DeriveKeyPair(ikm):
-  prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dkp_prk"), ikm)
+  prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dkp:prk"), ikm)
   sk = LabeledExpand(prk, "sk", zero(0), Nsk)
   return (sk, pk(sk))
 ~~~

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -862,8 +862,9 @@ def DeriveKeyPair(ikm):
 
 where `order` is the order of the curve being used (this can be found in
 section D.1.2 of {{NISTCurves}}), and `bitmask` is defined to be 0xFF for P-256
-and P-384, and 0x01 for P-521. The likelihood of DeriveKeyPair failing
-with DeriveKeyPairError depends on the group, but is negligible.
+and P-384, and 0x01 for P-521. The precise likelihood of DeriveKeyPair
+failing with DeriveKeyPairError depends on the group being used, but it
+is negligibly small in all cases.
 
 For X25519 and X448, the DeriveKeyPair function applies a KDF to the input:
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -851,6 +851,8 @@ def DeriveKeyPair(ikm):
   sk = 0
   counter = 1
   while sk == 0 or sk >= order:
+    if counter > 255:
+      raise DeriveKeyPairError
     bytes = LabeledExpand(dkp_prk, "candidate", I2OSP(counter, 1), Nsk)
     bytes[0] = bytes[0] & bitmask
     sk = OS2IP(bytes)
@@ -860,7 +862,8 @@ def DeriveKeyPair(ikm):
 
 where `order` is the order of the curve being used (this can be found in
 section D.1.2 of {{NISTCurves}}), and `bitmask` is defined to be 0xFF for P-256
-and P-384, and 0x01 for P-521.
+and P-384, and 0x01 for P-521. The likelihood of DeriveKeyPair failing
+with DeriveKeyPairError is 2^(-8160).
 
 For X25519 and X448, the DeriveKeyPair function applies a KDF to the input:
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -847,7 +847,7 @@ rejection sampling over field elements:
 
 ~~~
 def DeriveKeyPair(ikm):
-  prk = LabeledExtract(zero(0), I2OSP(kem_id, 2), ikm)
+  prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dkp_prk"), ikm)
   sk = 0
   counter = 1
   while sk == 0 or sk >= order:
@@ -866,8 +866,8 @@ For X25519 and X448, the DeriveKeyPair function applies a KDF to the input:
 
 ~~~
 def DeriveKeyPair(ikm):
-  prk = LabeledExtract(zero(0), I2OSP(kem_id, 2), ikm)
-  sk = Expand(prk, zero(0), Nsk)
+  prk = LabeledExtract(zero(0), concat(I2OSP(kem_id, 2), "dkp_prk"), ikm)
+  sk = LabeledExpand(prk, "sk", zero(0), Nsk)
   return (sk, pk(sk))
 ~~~
 


### PR DESCRIPTION
For consistency it would be nice to use LabeledExpand everywhere.

cc @rozbb 