### PR TITLE
Unify domain separation by including algorithm identifiers in each Extract and Expand call.

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -348,7 +348,7 @@ primitives is provided in {{ciphersuites}}.  Algorithm identifier
 values are two bytes long.
 
 The following two functions are defined to facilitate domain separation of
-KDF calls as well as context binding.
+KDF calls as well as context binding:
 
 ~~~
 def LabeledExtract(salt, label, IKM):


### PR DESCRIPTION
For DHKEM, the identifier is the KEM ID. For everything else, the identifier is
the combination of one-byte mode identifier and HPKE ciphersuite tuple.

This does more binding, in contrast to what's in #124.

cc @blipp