### PR TITLE
Unify separation by implicitly including algorithm identifiers

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -348,7 +348,7 @@ primitives is provided in {{ciphersuites}}.  Algorithm identifier
 values are two bytes long.
 
 The following two functions are defined to facilitate domain separation of
-KDF calls as well as context binding.
+KDF calls as well as context binding:
 
 ~~~
 def LabeledExtract(salt, label, IKM):

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -366,7 +366,7 @@ The value of `suite_id` depends on where the KDF is used; it is assumed
 implicit from the implementation and not passed as parameter. If used
 inside a KEM algorithm, `suite_id` MUST start with "KEM" and identify
 this KEM algorithm; if used in the remainder of HPKE, it MUST start with
-"DEM" and identify the entire ciphersuite in use. See sections {{dhkem}}
+"HPKE" and identify the entire ciphersuite in use. See sections {{dhkem}}
 and {{encryption-context}} for details.
 
 ## DH-Based KEM {#dhkem}
@@ -574,7 +574,7 @@ The implicit `suite_id` value used within `LabeledExtract` and
 
 ~~~
 suite_id = concat(
-  "DEM",
+  "HPKE",
   I2OSP(kem_id, 2),
   I2OSP(kdf_id, 2),
   I2OSP(aead_id, 2)
@@ -968,10 +968,10 @@ for the KDFs defined in this document, as inclusive bounds in bytes:
 
 | Input            | HKDF-SHA256  | HKDF-SHA384   | HKDF-SHA512   |
 |:-----------------|:-------------|:--------------|:--------------|
-| psk              | 2^{61} - 90  | 2^{125} - 154 | 2^{125} - 154 |
-| pskID            | 2^{61} - 92  | 2^{125} - 156 | 2^{125} - 156 |
-| info             | 2^{61} - 91  | 2^{125} - 155 | 2^{125} - 155 |
-| exporter_context | 2^{61} - 120 | 2^{125} - 200 | 2^{125} - 216 |
+| psk              | 2^{61} - 91  | 2^{125} - 155 | 2^{125} - 155 |
+| pskID            | 2^{61} - 93  | 2^{125} - 157 | 2^{125} - 157 |
+| info             | 2^{61} - 92  | 2^{125} - 156 | 2^{125} - 156 |
+| exporter_context | 2^{61} - 121 | 2^{125} - 201 | 2^{125} - 217 |
 
 This shows that the limits are only marginally smaller than the maximum
 input length of the underlying hash function; these limits are large and
@@ -1196,7 +1196,7 @@ inputs to the internal invocations of these functions inside Extract or
 Expand. In HPKE's KeySchedule this is avoided by using Extract instead of
 Hash on the arbitrary-length inputs `info`, `pskID`, and `psk`.
 
-The string literal "RFCXXXX" used in LabeledExtract and LabeledExpand
+The string literal "RFCXXXX " used in LabeledExtract and LabeledExpand
 ensures that any secrets derived in HPKE are bound to the scheme's name,
 even when possibly derived from the same Diffie-Hellman or KEM shared
 secret as in another scheme.

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -448,7 +448,6 @@ in {{kem-ids}}:
 identifier = I2OSP(kem_id, 2)
 ~~~
 
-
 The KDF used in DHKEM can be equal to or different from the KDF used
 in the remainder of HPKE, depending on the chosen variant.
 Implementations MUST make sure to use the constants (Nh) and function

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -440,8 +440,9 @@ def AuthDecap(enc, skR, pkS):
   return zz
 ~~~
 
-The `identifier` value used within `LabeledExtract` and `LabeledExpand`
-is defined as follows:
+The implicit `identifier` value used within `LabeledExtract` and
+`LabeledExpand` is defined as follows, where `kem_id` is defined
+in {{kem-ids}}:
 
 ~~~
 identifier = I2OSP(kem_id, 2)
@@ -566,10 +567,10 @@ then the recipient is assured that the sender held the corresponding
 pre-shared key (PSK). See {{sec-properties}} for more details.
 
 The HPKE algorithm identifiers, i.e., the KEM `kem_id`, KDF `kdf_id`, and
-AEAD `aead_id` 2-byte code points, are assumed implicit from the
-implementation and not passed as parameters. The implicit `identifier`
-value used within `LabeledExtract` and `LabeledExpand` is defined based
-on them as follows:
+AEAD `aead_id` 2-byte code points as defined in {{ciphersuites}}, are
+assumed implicit from the implementation and not passed as parameters.
+The implicit `identifier` value used within `LabeledExtract` and
+`LabeledExpand` is defined based on them as follows:
 
 ~~~
 identifier = concat(


### PR DESCRIPTION
I would like to make an alternative proposition to #126, based on it.

In this proposition, `identifier` is used as implicit parameter to `LabeledExtract` and `LabeledExpand`. This can be justified because the document already assumes that `kem_id`, `kdf_id`, `aead_id` are implicitly encoded into the implementation. The advantage of having `identifier` implicit is that this removes clutter from the other function definitions; this might make implementation work easier because the calls to LabeledExtract and LabeledExpand then have fewer nested parameters.

On the question if `mode` should be in the identifier: if `mode` should be in the identifier, it is hard to let `identifier` be an implicit parameter, because the `mode` parameter is an explicit parameter (which is needed for `VerifyPSKInputs`). I thought about if we can find a reason why *not* including `mode` in the identifier is justified from a provable security point-of-view. I came to the conclusion this works out, because:

The first calls in `KeySchedule` are, from a variable dependencies point of view:
```
  psk_hash = LabeledExtract(zero(0), "psk_hash", psk)
  secret = LabeledExtract(psk_hash, "secret", zz)
```

All the following KDF calls include `mode` because it is in the `key_schedule_context`, so those are safe. Values of `secret` cannot collide between different modes, because:
- `zz` is the same for the Base and PSK modes, but `psk_hash` is different for these modes (default_psk vs non-defaut)
- `zz` is the same for the Auth and AuthPSK modes, but `psk_hash` is different for these modes (default_psk vs non-defaut)

This means we do not need to domain-separate by the mode in each call, because the two LabeledExtracts above already have a clear-enough dependency on the mode; which allows us to have `identifier` be implicit and have cleaner function definitions.