### PR TITLE
Use email address that is available long-term

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -23,7 +23,7 @@ author:
  -  ins: B. Lipp
     name: Benjamin Lipp
     org: Inria
-    email: benjamin.lipp@inria.fr
+    email: ietf@benjaminlipp.de
  -  ins: C. A. Wood
     name: Christopher A. Wood
     org: Cloudflare


### PR DESCRIPTION
My Inria email address will become unavailable in roughly 2 years, so I thought I'd include one that is supposed to live longer.