### PR TITLE
Require PSKs have at least 32 bytes of entropy.

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -1191,7 +1191,7 @@ for `Extract()` without restriction on the key's length.
 ## Pre-Shared Key Recommendations {#security-psk}
 
 In the PSK and AuthPSK modes, the PSK MUST have at least 32 bytes of
-entropy and SHOULD be of length Nh bytes or longer. Using a PSK longer than
+entropy and SHOULD be of length `Nh` bytes or longer. Using a PSK longer than
 32 bytes but shorter than `Nh` bytes is permitted. A PSK that is longer than
 `Nh` bytes or that has more than `Nh` bytes of entropy, respectively, does
 not increase the security level of HPKE, because the extraction step involving

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -698,7 +698,7 @@ byte string `psk_id` that is used to identify which PSK should be used.
 The primary difference from the base case is that the `psk` and `psk_id` values
 are used as `ikm` inputs to the KDF (instead of using the empty string).
 
-The PSK MUST have at least 32 bytes of entropy and SHOULD be of length Nh
+The PSK MUST have at least 32 bytes of entropy and SHOULD be of length `Nh`
 bytes or longer. See {{security-psk}} for a more detailed discussion.
 
 ~~~~~

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -1211,7 +1211,7 @@ the case if the adversary acts as sender.
 
 To recover a lower entropy PSK, an attacker in this scenario can trivially
 perform a dictionary attack. Given a set `S` of possible PSK values, the
-attacker generates an HPKE ciphertext using each value in `S`, and submits
+attacker generates an HPKE ciphertext for each value in `S`, and submits
 the resulting ciphertexts to the oracle to learn which PSK is being used by
 the receiver. Further, because HPKE uses AEAD schemes that are not key-committing,
 an attacker can mount a partitioning oracle attack {{LGR20}} which can recover

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -765,7 +765,7 @@ def SetupAuthPSKR(enc, skR, info, psk, psk_id, pkS):
   return KeySchedule(mode_auth_psk, shared_secret, info, psk, psk_id)
 ~~~~~
 
-The PSK MUST have at least 32 bytes of entropy and SHOULD be of length Nh
+The PSK MUST have at least 32 bytes of entropy and SHOULD be of length `Nh`
 bytes or longer. See {{security-psk}} for a more detailed discussion.
 
 ## Encryption and Decryption {#hpke-dem}

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -166,20 +166,20 @@ informative:
 
   LGR20:
     title: "Partitioning Oracle Attacks"
-    date: In preparation
+    date: To appear in USENIX Security 2021
     author:
       -
         ins: J. Len
         name: Julia Len
-        org: Cornell University
+        org: Cornell Tech
       -
         ins: P. Grubbs
         name: Paul Grubbs
-        org: Cornell University
+        org: Cornell Tech
       -
         ins: T. Ristenpart
         name: Thomas Ristenpart
-        org: Cornell University
+        org: Cornell Tech
 
   TestVectors:
     title: "HPKE Test Vectors"

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -1205,7 +1205,7 @@ PSK: in scenarios in which the adversary knows the KEM shared secret
 a good and a wrong PSK, it can perform PSK-recovering attacks. This oracle
 can be the decryption operation on a captured HPKE ciphertext or any other
 recipient behavior which is observably different when using a wrong PSK.
-The adversary knows the KEM shared secret shared_secret if it knows all
+The adversary knows the KEM shared secret `shared_secret` if it knows all
 KEM private keys of one participant. In the PSK mode this is trivially
 the case if the adversary acts as sender.
 


### PR DESCRIPTION
Closes #155.

Note that we *could* replace the lower bound with `Nh` rather than `32`, but I think this is a bit too conservative. We currently allow PSKs that are less than `Nh` bytes in length, so using a constant `32` is not a regression. (I do agree that it's cleaner to just use `Nh`!)

cc @blipp