### PR TITLE
About KEM Key Reuse

### DIFF
--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -1106,14 +1106,13 @@ reused elsewhere, in particular not with `DeriveKeyPair()` of a
 different KEM.
 
 The randomness used in `Encap()` and `AuthEncap()` to generate the
-KEM shared secret and its encapsulation MUST NOT be reused elsewhere.
+KEM shared secret and/or its encapsulation MUST NOT be reused elsewhere.
 
-Sender and receiver KEM key pairs are valid 
-
-A sender or receiver KEM key pair
-
-
-
+A sender or recipient KEM key pair works with all modes, it could thus
+be used with multiple modes in parallel. HPKE is constructed to be
+secure in such settings due to domain separation using the `suite_id`
+variable. However, there is no formal proof of security at the time of
+writing -- {{HPKEAnalysis}} and {{ABHKLR20}} only analyze isolated modes.
 
 ### Future KEMs {#future-kems}
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -1028,6 +1028,10 @@ The keys that `DeriveKeyPair()` produces have only as much entropy as the provid
 input keying material. For a given KEM, the `ikm` parameter given to `DeriveKeyPair()` SHOULD
 have length at least `Nsk`, and SHOULD have at least `Nsk` bytes of entropy.
 
+A value `ikm` used with `DeriveKeyPair()` MUST NOT be reused elsewhere,
+in particular not for other invocations of `DeriveKeyPair()`, be it for
+the same or a different KEM.
+
 All invocations of KDF functions (such as `LabeledExtract` or `LabeledExpand`) in any
 DHKEM's `DeriveKeyPair()` function use the DHKEM's associated KDF (as opposed to
 the ciphersuite's KDF).

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -1108,7 +1108,7 @@ different KEM.
 The randomness used in `Encap()` and `AuthEncap()` to generate the
 KEM shared secret or its encapsulation MUST NOT be reused elsewhere.
 
-A sender or recipient KEM key pair works with all modes, it could thus
+As a sender or recipient KEM key pair works with all modes, it can
 be used with multiple modes in parallel. HPKE is constructed to be
 secure in such settings due to domain separation using the `suite_id`
 variable. However, there is no formal proof of security at the time of

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -1101,14 +1101,12 @@ the Diffie-Hellman shared secret is the all-zero value and abort if so.
 
 ### KEM Key Reuse
 
+An `ikm` input to `DeriveKeyPair()` ({{derive-key-pair}}) MUST NOT be
+reused elsewhere, in particular not with `DeriveKeyPair()` of a
+different KEM.
 
-A value `ikm` used with `DeriveKeyPair()` MUST NOT be reused elsewhere,
-in particular not for other invocations of `DeriveKeyPair()`, be it for
-the same or a different KEM.
-
-An `ikm` input to `DeriveKeyPair()` ({{derive-key-pair}}) MUST NOT be reused elsewhere, in particular not with `DeriveKeyPair()` of a different KEM.
-
-Ephemeral KEM key pairs MUST NOT be reused.
+The randomness used in `Encap()` and `AuthEncap()` to generate the
+KEM shared secret and its encapsulation MUST NOT be reused elsewhere.
 
 Sender and receiver KEM key pairs are valid 
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -1106,7 +1106,7 @@ reused elsewhere, in particular not with `DeriveKeyPair()` of a
 different KEM.
 
 The randomness used in `Encap()` and `AuthEncap()` to generate the
-KEM shared secret and/or its encapsulation MUST NOT be reused elsewhere.
+KEM shared secret or its encapsulation MUST NOT be reused elsewhere.
 
 A sender or recipient KEM key pair works with all modes, it could thus
 be used with multiple modes in parallel. HPKE is constructed to be

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -1112,7 +1112,7 @@ As a sender or recipient KEM key pair works with all modes, it can
 be used with multiple modes in parallel. HPKE is constructed to be
 secure in such settings due to domain separation using the `suite_id`
 variable. However, there is no formal proof of security at the time of
-writing -- {{HPKEAnalysis}} and {{ABHKLR20}} only analyze isolated modes.
+writing; {{HPKEAnalysis}} and {{ABHKLR20}} only analyze isolated modes.
 
 ### Future KEMs {#future-kems}
 

--- a/draft-irtf-cfrg-hpke.md
+++ b/draft-irtf-cfrg-hpke.md
@@ -1028,10 +1028,6 @@ The keys that `DeriveKeyPair()` produces have only as much entropy as the provid
 input keying material. For a given KEM, the `ikm` parameter given to `DeriveKeyPair()` SHOULD
 have length at least `Nsk`, and SHOULD have at least `Nsk` bytes of entropy.
 
-A value `ikm` used with `DeriveKeyPair()` MUST NOT be reused elsewhere,
-in particular not for other invocations of `DeriveKeyPair()`, be it for
-the same or a different KEM.
-
 All invocations of KDF functions (such as `LabeledExtract` or `LabeledExpand`) in any
 DHKEM's `DeriveKeyPair()` function use the DHKEM's associated KDF (as opposed to
 the ciphersuite's KDF).
@@ -1102,6 +1098,24 @@ Diffie-Hellman shared secret is not the point at infinity.
 For X25519 and X448, public keys and Diffie-Hellman outputs MUST be validated
 as described in {{?RFC7748}}. In particular, recipients MUST check whether
 the Diffie-Hellman shared secret is the all-zero value and abort if so.
+
+### KEM Key Reuse
+
+
+A value `ikm` used with `DeriveKeyPair()` MUST NOT be reused elsewhere,
+in particular not for other invocations of `DeriveKeyPair()`, be it for
+the same or a different KEM.
+
+An `ikm` input to `DeriveKeyPair()` ({{derive-key-pair}}) MUST NOT be reused elsewhere, in particular not with `DeriveKeyPair()` of a different KEM.
+
+Ephemeral KEM key pairs MUST NOT be reused.
+
+Sender and receiver KEM key pairs are valid 
+
+A sender or receiver KEM key pair
+
+
+
 
 ### Future KEMs {#future-kems}
 


### PR DESCRIPTION
Polished alternative to #210.

Proving security when using multiple modes in parallel should be doable with the models and CryptoVerif files prepared so far. However, I cannot spend time on it before May.

Reusing `ikm` elsewhere would be really inconvenient for proofs: at some point _we have_ to assume that _something_ is freshly random and not reused anywhere else, and I think drawing that line at the kind of root entry point, the KEM key pair, is good.

Closes #210.